### PR TITLE
add github action release trigger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,11 @@ orbs:
   codecov: codecov/codecov@3.2.2
   jq: circleci/jq@2.2.0
 
+parameters:
+  GHA_Event:
+    type: string
+    default: ""
+
 workflows:
   web-build-and-test:
     jobs:
@@ -49,6 +54,7 @@ workflows:
     when:
       and:
         - equal: [ main, << pipeline.git.branch >> ]
+        - equal: [ "release", << pipeline.parameters.GHA_Event >> ]
     jobs:
       - node/run:
           name: publish

--- a/.github/workflows/trigger-circleci.yml
+++ b/.github/workflows/trigger-circleci.yml
@@ -1,0 +1,11 @@
+on:
+  release:
+    types: [published]
+jobs:
+  trigger-circleci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger circleci
+        uses: circleci/trigger_circleci_pipeline@v1.0
+        env:
+          CCI_TOKEN: $


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [X] Feature
- [ ] Bug fix

### Linked issue

- [X] Not tracked

### Why
The CircleCI publishing workflow is faster than the release versioning gitHub action. Package versions are 1 minor version behind main.

### How
By adding a gitHub action that can trigger the CircleCI workflow when it has completed adding a new release.