### PR TITLE
feat: add trade-confirm dialog

### DIFF
--- a/library/src/app/components/trade-confirm/trade-confirm.component.html
+++ b/library/src/app/components/trade-confirm/trade-confirm.component.html
@@ -1,0 +1,128 @@
+<div
+  [ngClass]="{
+    'cybrid-dark-theme': (configService.config$ | async)?.theme === 'DARK'
+  }"
+>
+  <ng-container *ngIf="(isRecoverable$ | async) !== false; else error">
+    <ng-container *ngIf="quote$ | async as quote; else loading">
+      <h2 mat-dialog-title>{{ 'trade.confirm.header' | translate }}</h2>
+      <mat-dialog-content>
+        <span class="mat-hint"
+          >{{ 'trade.confirm.refresh.message' | translate }}
+          {{ ' ' + refreshInterval / 1000 + ' ' }}
+          {{ 'trade.confirm.refresh.unit' | translate }}</span
+        >
+        <mat-list *ngIf="data.model.side === 'buy'" role="list">
+          <mat-list-item>
+            <div class="list-item">
+              <span>{{
+                ('trade.confirm.purchase' | translate) +
+                  ' ' +
+                  ('trade.amount' | translate)
+              }}</span>
+              <div>
+                <span class="mat-body">
+                  {{ (quote.deliver_amount! | asset: counter_asset) + ' ' }}
+                </span>
+                <span class="mat-body mat-hint">{{ counter_asset.code }}</span>
+              </div>
+            </div>
+          </mat-list-item>
+          <mat-divider></mat-divider>
+          <mat-list-item>
+            <div class="list-item">
+              <span>{{
+                ('trade.confirm.purchase' | translate) +
+                  ' ' +
+                  ('trade.quantity' | translate)
+              }}</span>
+              <div>
+                <span class="mat-body">{{
+                  (quote.receive_amount! | asset: asset:'trade') + ' '
+                }}</span>
+                <span class="mat-body mat-hint">{{ asset.code }}</span>
+              </div>
+            </div>
+          </mat-list-item>
+          <mat-divider></mat-divider>
+          <mat-list-item>
+            <div class="list-item">
+              <span>{{ 'trade.confirm.transaction' | translate }}</span>
+              <div>
+                <span class="mat-body"
+                  >{{ (quote.fee! | asset: counter_asset:'trade') + ' ' }}
+                </span>
+                <span class="mat-body mat-hint">{{ counter_asset.code }}</span>
+              </div>
+            </div>
+          </mat-list-item>
+          <mat-divider></mat-divider>
+        </mat-list>
+        <mat-list *ngIf="data.model.side === 'sell'" role="list">
+          <mat-list-item>
+            <div class="list-item">
+              <span>{{
+                ('trade.sell' | translate) + ' ' + ('trade.amount' | translate)
+              }}</span>
+              <div>
+                <span class="mat-body">{{
+                  (quote.receive_amount! | asset: counter_asset) + ' '
+                }}</span>
+                <span class="mat-body mat-hint"> {{ counter_asset.code }}</span>
+              </div>
+            </div>
+          </mat-list-item>
+          <mat-divider></mat-divider>
+          <mat-list-item>
+            <div class="list-item">
+              <span>{{
+                ('trade.sell' | translate) +
+                  ' ' +
+                  ('trade.quantity' | translate)
+              }}</span>
+              <div>
+                <span>{{
+                  (quote.deliver_amount! | asset: asset:'trade') + ' '
+                }}</span>
+                <span class="mat-body mat-hint">{{ asset.code }}</span>
+              </div>
+            </div>
+          </mat-list-item>
+          <mat-divider></mat-divider>
+          <mat-list-item>
+            <div class="list-item">
+              <span>{{ 'trade.confirm.transaction' | translate }}</span>
+              <div>
+                <span class="mat-body">{{
+                  (quote.fee! | asset: counter_asset) + ' '
+                }}</span>
+                <span class="mat-body mat-hint">{{ counter_asset.code }}</span>
+              </div>
+            </div>
+          </mat-list-item>
+          <mat-divider></mat-divider>
+        </mat-list>
+      </mat-dialog-content>
+      <mat-dialog-actions align="end">
+        <button mat-button [mat-dialog-close]>
+          {{ 'cancel' | translate }}
+        </button>
+        <button mat-flat-button color="primary" (click)="onConfirmTrade()">
+          {{ 'confirm' | translate }}
+        </button>
+      </mat-dialog-actions>
+    </ng-container>
+  </ng-container>
+  <ng-template #loading>
+    <mat-spinner diameter="40"></mat-spinner>
+  </ng-template>
+  <ng-template #error>
+    <mat-card>
+      <mat-card-content>
+        <div class="fatal">
+          <p>{{ 'fatal' | translate }}</p>
+        </div>
+      </mat-card-content>
+    </mat-card>
+  </ng-template>
+</div>

--- a/library/src/app/components/trade-confirm/trade-confirm.component.scss
+++ b/library/src/app/components/trade-confirm/trade-confirm.component.scss
@@ -1,0 +1,13 @@
+@use '@angular/material' as mat;
+@import url('https://fonts.googleapis.com/icon?family=Material+Icons');
+@import '../../../../../src/shared/styles/theme.scss';
+
+.list-item {
+  display: flex;
+  flex-grow: 1;
+  justify-content: space-between;
+}
+
+mat-divider {
+  margin: 0 1rem;
+}

--- a/library/src/app/components/trade-confirm/trade-confirm.component.spec.ts
+++ b/library/src/app/components/trade-confirm/trade-confirm.component.spec.ts
@@ -1,0 +1,169 @@
+import {
+  ComponentFixture,
+  discardPeriodicTasks,
+  fakeAsync,
+  TestBed,
+  tick
+} from '@angular/core/testing';
+
+import { TradeConfirmComponent } from './trade-confirm.component';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef
+} from '@angular/material/dialog';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import {
+  TranslateLoader,
+  TranslateModule,
+  TranslatePipe
+} from '@ngx-translate/core';
+import { HttpLoaderFactory } from '../../modules/library.module';
+import { HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { EventService } from '../../../../../src/shared/services/event/event.service';
+import { ErrorService } from '../../../../../src/shared/services/error/error.service';
+import { ConfigService } from '../../../../../src/shared/services/config/config.service';
+import { of, throwError } from 'rxjs';
+import { TestConstants } from '../../../../../src/shared/constants/test.constants';
+import { QuotesService, TradesService } from '@cybrid/cybrid-api-bank-angular';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('TradeConfirmComponent', () => {
+  let component: TradeConfirmComponent;
+  let fixture: ComponentFixture<TradeConfirmComponent>;
+
+  let MockEventService = jasmine.createSpyObj('EventService', [
+    'getEvent',
+    'handleEvent'
+  ]);
+  let MockErrorService = jasmine.createSpyObj('ErrorService', [
+    'getError',
+    'handleError'
+  ]);
+  let MockConfigService = jasmine.createSpyObj('ConfigService', [
+    'setConfig',
+    'getConfig$'
+  ]);
+  let MockQuotesService = jasmine.createSpyObj('QuotesService', [
+    'createQuote'
+  ]);
+  let MockTradesService = jasmine.createSpyObj('TradesService', [
+    'createTrade'
+  ]);
+  let MockSnackbar = jasmine.createSpyObj('Snackbar', ['open']);
+  let MockDialogRef = jasmine.createSpyObj('MatDialogRef', ['open', 'close']);
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TradeConfirmComponent],
+      imports: [
+        BrowserAnimationsModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        MatSnackBarModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useFactory: HttpLoaderFactory,
+            deps: [HttpClient]
+          }
+        })
+      ],
+      providers: [
+        { provide: MatDialogRef, useValue: MockDialogRef },
+        { provide: MatSnackBar, useValue: MockSnackbar },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: EventService, useValue: MockEventService },
+        { provide: ErrorService, useValue: MockErrorService },
+        { provide: ConfigService, useValue: MockConfigService },
+        { provide: QuotesService, useValue: MockQuotesService },
+        { provide: TradesService, useValue: MockTradesService },
+        TranslatePipe
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    }).compileComponents();
+    MockDialogRef = TestBed.inject(MatDialogRef);
+    MockDialogRef.open.and.returnValue({ afterClosed: () => of({ id: 1 }) });
+    MockEventService = TestBed.inject(EventService);
+    MockErrorService = TestBed.inject(ErrorService);
+    MockConfigService = TestBed.inject(ConfigService);
+    MockConfigService.getConfig$.and.returnValue(of(TestConstants.CONFIG));
+    MockQuotesService = TestBed.inject(QuotesService);
+    MockQuotesService.createQuote.and.returnValue(of(TestConstants.QUOTE));
+    MockTradesService.createTrade.and.returnValue(of({}));
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TradeConfirmComponent);
+    component = fixture.componentInstance;
+    component.data = {
+      model: TestConstants.POST_QUOTE,
+      asset: TestConstants.BTC_ASSET,
+      counter_asset: TestConstants.USD_ASSET
+    };
+    fixture.detectChanges();
+    component.ngOnInit();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should fetch the refresh interval', () => {
+    expect(component.refreshInterval).toEqual(
+      TestConstants.CONFIG.refreshInterval
+    );
+  });
+
+  it('should create a quote', () => {
+    expect(component.postTradeBankModel.quote_guid).toEqual(
+      TestConstants.QUOTE.guid!
+    );
+    component.quote$.subscribe((quote) => {
+      expect(quote).toEqual(TestConstants.QUOTE);
+    });
+  });
+
+  it('should catch errors when creating a quote', () => {
+    const refreshSubSpy = spyOn(component.refreshSub, 'unsubscribe');
+    const error$ = throwError(() => {
+      new Error('Error');
+    });
+    MockQuotesService.createQuote.and.returnValue(error$);
+    component.createQuote();
+    expect(refreshSubSpy).toHaveBeenCalled();
+    expect(MockSnackbar.open).toHaveBeenCalled();
+    expect(MockEventService.handleEvent).toHaveBeenCalled();
+    expect(MockErrorService.handleError).toHaveBeenCalled();
+    expect(MockDialogRef.close).toHaveBeenCalled();
+  });
+
+  it('should refresh data', fakeAsync(() => {
+    const createQuoteSpy = spyOn(component, 'createQuote');
+    component.ngOnInit();
+    tick(TestConstants.CONFIG.refreshInterval);
+    expect(createQuoteSpy).toHaveBeenCalledTimes(2);
+    expect(MockEventService.handleEvent).toHaveBeenCalled();
+    discardPeriodicTasks();
+  }));
+
+  it('should create trade onConfirmTrade()', () => {
+    component.onConfirmTrade();
+    expect(MockTradesService.createTrade).toHaveBeenCalled();
+    expect(MockDialogRef.close).toHaveBeenCalled();
+  });
+
+  it('should catch errors when creating a trade', () => {
+    const error$ = throwError(() => {
+      new Error('Error');
+    });
+    MockTradesService.createTrade.and.returnValue(error$);
+    component.onConfirmTrade();
+    expect(MockSnackbar.open).toHaveBeenCalled();
+    expect(MockEventService.handleEvent).toHaveBeenCalled();
+    expect(MockErrorService.handleError).toHaveBeenCalled();
+    expect(MockDialogRef.close).toHaveBeenCalled();
+  });
+});

--- a/library/src/app/components/trade-confirm/trade-confirm.component.ts
+++ b/library/src/app/components/trade-confirm/trade-confirm.component.ts
@@ -1,0 +1,168 @@
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import {
+  PostTradeBankModel,
+  QuoteBankModel,
+  QuotesService,
+  TradesService
+} from '@cybrid/cybrid-api-bank-angular';
+import {
+  BehaviorSubject,
+  catchError,
+  map,
+  of,
+  Subject,
+  Subscription,
+  switchMap,
+  takeUntil,
+  timer
+} from 'rxjs';
+import {
+  ComponentConfig,
+  ConfigService
+} from '../../../../../src/shared/services/config/config.service';
+import {
+  CODE,
+  EventService,
+  LEVEL
+} from '../../../../../src/shared/services/event/event.service';
+import { ErrorService } from '../../../../../src/shared/services/error/error.service';
+import { Asset } from '../../../../../src/shared/services/asset/asset.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { TranslatePipe } from '@ngx-translate/core';
+
+@Component({
+  selector: 'app-trade-confirm',
+  templateUrl: './trade-confirm.component.html',
+  styleUrls: ['./trade-confirm.component.scss']
+})
+export class TradeConfirmComponent implements OnInit, OnDestroy {
+  quote$: Subject<QuoteBankModel> = new Subject<QuoteBankModel>();
+  asset: Asset = this.data.asset;
+  counter_asset: Asset = this.data.counter_asset;
+  refreshInterval = 0;
+
+  postTradeBankModel: PostTradeBankModel = {
+    quote_guid: ''
+  };
+
+  isRecoverable$ = new BehaviorSubject(true);
+  unsubscribe$ = new Subject();
+  refreshSub: Subscription = new Subscription();
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: any,
+    public dialogRef: MatDialogRef<TradeConfirmComponent>,
+    private snackBar: MatSnackBar,
+    public configService: ConfigService,
+    private quotesService: QuotesService,
+    private tradesService: TradesService,
+    private eventService: EventService,
+    private errorService: ErrorService,
+    private translatePipe: TranslatePipe
+  ) {}
+
+  ngOnInit(): void {
+    this.getRefreshInterval();
+    this.createQuote();
+    this.refreshData();
+  }
+
+  ngOnDestroy() {
+    this.unsubscribe$.next('');
+    this.unsubscribe$.complete();
+  }
+
+  getRefreshInterval(): void {
+    this.configService
+      .getConfig$()
+      .pipe(
+        takeUntil(this.unsubscribe$),
+        map((config) => (this.refreshInterval = config.refreshInterval))
+      )
+      .subscribe();
+  }
+
+  createQuote(): void {
+    this.eventService.handleEvent(
+      LEVEL.INFO,
+      CODE.DATA_FETCHING,
+      'Fetching quote...'
+    );
+    this.quotesService
+      .createQuote(this.data.model)
+      .pipe(
+        map((quote) => {
+          this.postTradeBankModel.quote_guid = quote.guid!;
+          this.quote$.next(quote);
+        }),
+        catchError((err: any) => {
+          const message = this.translatePipe.transform(
+            'trade.confirm.error.quote'
+          );
+          this.snackBar.open(message, undefined, {
+            duration: 3000
+          });
+          this.refreshSub.unsubscribe();
+          this.eventService.handleEvent(
+            LEVEL.ERROR,
+            CODE.DATA_ERROR,
+            'Error fetching quote'
+          );
+          this.errorService.handleError(err);
+          this.dialogRef.close();
+          return of(err);
+        })
+      )
+      .subscribe();
+  }
+
+  refreshData(): void {
+    this.refreshSub = this.configService
+      .getConfig$()
+      .pipe(
+        switchMap((cfg: ComponentConfig) => {
+          return timer(cfg.refreshInterval, cfg.refreshInterval);
+        }),
+        takeUntil(this.unsubscribe$)
+      )
+      .subscribe({
+        next: () => {
+          this.eventService.handleEvent(
+            LEVEL.INFO,
+            CODE.DATA_FETCHING,
+            'Refreshing quote...'
+          );
+          this.createQuote();
+        }
+      });
+  }
+
+  onConfirmTrade(): void {
+    this.tradesService
+      .createTrade(this.postTradeBankModel)
+      .pipe(
+        map((trade) => {
+          this.dialogRef.close(trade);
+        }),
+        catchError((err: any) => {
+          const message = this.translatePipe.transform(
+            'trade.confirm.error.trade'
+          );
+          this.snackBar.open(message, undefined, {
+            duration: 3000
+          });
+          this.refreshSub.unsubscribe();
+          this.eventService.handleEvent(
+            LEVEL.ERROR,
+            CODE.DATA_ERROR,
+            'Error confirming trade'
+          );
+          this.errorService.handleError(err);
+          this.dialogRef.close();
+          return of(err);
+        })
+      )
+      .subscribe();
+  }
+}

--- a/library/src/app/components/trade/trade.component.html
+++ b/library/src/app/components/trade/trade.component.html
@@ -7,7 +7,7 @@
     <ng-container *ngIf="(isLoading$ | async) !== true">
       <mat-tab-group
         animationDuration="0ms"
-        (selectedTabChange)="onSwitchSide($event.tab.textLabel)"
+        (selectedTabChange)="onSwitchSide($event.tab.origin)"
       >
         <mat-tab label="{{ 'trade.buy' | translate }}"> </mat-tab>
         <mat-tab label="{{ 'trade.sell' | translate }}"></mat-tab>
@@ -45,7 +45,7 @@
           </mat-form-field>
           <mat-form-field appearance="outline">
             <mat-label>
-              <span>{{ 'trade.amount' | translate }}</span>
+              <span>{{ 'trade.amount' | translate | titlecase }}</span>
             </mat-label>
             <input
               matInput
@@ -116,11 +116,12 @@
             class="action"
             mat-flat-button
             color="primary"
+            (click)="onTrade()"
             [disabled]="
               !quoteGroup.valid || !(amount.value.toString().length > 0)
             "
           >
-            {{ side.toString() | translate | titlecase }}
+            {{ 'trade.' + side.toString() | translate | titlecase }}
           </button>
         </div>
       </ng-container>

--- a/library/src/app/components/trade/trade.component.ts
+++ b/library/src/app/components/trade/trade.component.ts
@@ -40,6 +40,8 @@ import { getFiatIcon } from '../../../../../src/shared/utility/fiat-icon';
 import SideEnum = PostQuoteBankModel.SideEnum;
 import { Constants } from '../../../../../src/shared/constants/constants';
 import { QuoteService } from '../../../../../src/shared/services/quote/quote.service';
+import { TradeConfirmComponent } from '../trade-confirm/trade-confirm.component';
+import { MatDialog } from '@angular/material/dialog';
 
 @Component({
   selector: 'app-trade',
@@ -87,6 +89,7 @@ export class TradeComponent implements OnInit, OnDestroy {
     public configService: ConfigService,
     private quoteService: QuoteService,
     private pricesService: PricesService,
+    public dialog: MatDialog,
     private assetPipe: AssetPipe,
     private route: ActivatedRoute
   ) {}
@@ -154,9 +157,7 @@ export class TradeComponent implements OnInit, OnDestroy {
     this.quoteGroup.valueChanges
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe((value) => {
-        if (this.input == 'asset') {
-          this.asset = value.asset;
-        }
+        this.asset = value.asset;
         this.amount = value.amount;
         this.getPrice();
       });
@@ -256,13 +257,13 @@ export class TradeComponent implements OnInit, OnDestroy {
     this.getPrice();
   }
 
-  onSwitchSide(tab: string): void {
+  onSwitchSide(tab: number | null): void {
     switch (tab) {
-      case 'Buy': {
+      case -1: {
         this.side = SideEnum.Buy;
         break;
       }
-      case 'Sell': {
+      case 1: {
         this.side = SideEnum.Sell;
         break;
       }
@@ -271,14 +272,19 @@ export class TradeComponent implements OnInit, OnDestroy {
   }
 
   onTrade(): void {
-    this.quote$.next(
-      this.quoteService.getQuote(
-        this.amount,
-        this.input,
-        this.side,
-        this.asset,
-        this.counterAsset
-      )
+    const postQuoteBankModel: PostQuoteBankModel = this.quoteService.getQuote(
+      this.amount,
+      this.input,
+      this.side,
+      this.asset,
+      this.counterAsset
     );
+    this.dialog.open(TradeConfirmComponent, {
+      data: {
+        model: postQuoteBankModel,
+        asset: this.asset,
+        counter_asset: this.counterAsset
+      }
+    });
   }
 }

--- a/library/src/app/modules/library.module.ts
+++ b/library/src/app/modules/library.module.ts
@@ -18,7 +18,11 @@ import { createCustomElement } from '@angular/elements';
 
 // Modules
 import { ApiModule, Configuration } from '@cybrid/cybrid-api-bank-angular';
-import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
+import {
+  TranslateModule,
+  TranslateLoader,
+  TranslatePipe
+} from '@ngx-translate/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MaterialModule } from '../../../../src/shared/modules/material-module';
 
@@ -36,6 +40,7 @@ import { RetryInterceptor } from '../../../../src/shared/interceptors/auth/retry
 import { AppComponent } from '../components/app/app.component';
 import { PriceListComponent } from '../components/price-list/price-list.component';
 import { TradeComponent } from '../components/trade/trade.component';
+import { TradeConfirmComponent } from '../components/trade-confirm/trade-confirm.component';
 
 // Utility
 import { environment } from '../../environments/environment';
@@ -47,7 +52,13 @@ export function HttpLoaderFactory(http: HttpClient) {
 }
 
 @NgModule({
-  declarations: [AppComponent, PriceListComponent, TradeComponent, AssetPipe],
+  declarations: [
+    AppComponent,
+    PriceListComponent,
+    TradeComponent,
+    TradeConfirmComponent,
+    AssetPipe
+  ],
   imports: [
     BrowserModule,
     BrowserAnimationsModule,
@@ -84,6 +95,7 @@ export function HttpLoaderFactory(http: HttpClient) {
     EventService,
     AssetService,
     AssetPipe,
+    TranslatePipe,
     { provide: APP_BASE_HREF, useValue: '' },
     { provide: HTTP_INTERCEPTORS, useClass: RetryInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor, multi: true },

--- a/src/shared/constants/test.constants.ts
+++ b/src/shared/constants/test.constants.ts
@@ -1,4 +1,8 @@
-import { SymbolPriceBankModel } from '@cybrid/cybrid-api-bank-angular';
+import {
+  PostQuoteBankModel,
+  QuoteBankModel,
+  SymbolPriceBankModel
+} from '@cybrid/cybrid-api-bank-angular';
 import { SymbolPrice } from '../../../library/src/app/components/price-list/price-list.component';
 import { ComponentConfig } from '../services/config/config.service';
 import { Asset } from '../services/asset/asset.service';
@@ -68,4 +72,21 @@ export class TestConstants {
     customer: ''
   };
   static ICON_URL: string = 'https://images.cybrid.xyz/color/eth.svg';
+  static POST_QUOTE: PostQuoteBankModel = {
+    customer_guid: '378c691c1b5ba3b938e17c1726202fe4',
+    symbol: 'BTC-USD',
+    side: 'buy',
+    receive_amount: 100000000
+  };
+  static QUOTE: QuoteBankModel = {
+    guid: 'f92faf30047aca08b95bf10aecb96254',
+    customer_guid: '378c691c1b5ba3b938e17c1726202fe4',
+    symbol: 'ETH-USD',
+    side: 'buy',
+    receive_amount: 1000000000000000000,
+    deliver_amount: 109028,
+    fee: 0,
+    issued_at: '2022-06-22T13:30:58.078Z',
+    expires_at: '2022-06-22T13:31:28.078Z'
+  };
 }

--- a/src/shared/i18n/en.ts
+++ b/src/shared/i18n/en.ts
@@ -1,4 +1,10 @@
 export default {
+  // General
+  cancel: 'Cancel',
+  confirm: 'Confirm',
+  fatal: 'An unrecoverable error occurred',
+
+  // Price list component
   priceList: {
     title: 'Price List',
     table: {
@@ -10,12 +16,29 @@ export default {
     empty: 'No coins found',
     refreshButton: 'Refresh'
   },
+
+  // Trade component
   trade: {
-    amount: 'Amount',
+    amount: 'amount',
+    quantity: 'quantity',
     currency: 'Currency',
     buy: 'Buy',
     sell: 'Sell',
-    error: 'Positive number required'
-  },
-  fatal: 'An unrecoverable error occurred'
+    error: 'Positive number required',
+
+    // Confirm dialog
+    confirm: {
+      header: 'Order Quote',
+      refresh: {
+        message: 'Market rates will automatically refresh every',
+        unit: 'seconds'
+      },
+      purchase: 'Purchase',
+      transaction: 'Transaction fee',
+      error: {
+        quote: 'Error fetching quote',
+        trade: 'Error confirming trade'
+      }
+    }
+  }
 };

--- a/src/shared/i18n/fr.ts
+++ b/src/shared/i18n/fr.ts
@@ -1,4 +1,10 @@
 export default {
+  // General
+  cancel: 'Annuler',
+  confirm: 'Confirmer',
+  fatal: "Une erreur irrécupérable s'est produite",
+
+  // Price list component
   priceList: {
     title: 'Liste de prix',
     table: {
@@ -10,12 +16,30 @@ export default {
     empty: 'Aucune pièce trouvée',
     refreshButton: 'Rafraîchir'
   },
+
+  // Trade component
   trade: {
-    amount: 'Montant',
+    amount: 'montant',
+    quantity: 'quantité',
     currency: 'Devise',
     buy: 'Acheter',
     sell: 'Vendre',
-    error: 'Nombre positif requis'
-  },
-  fatal: "Une erreur irrécupérable s'est produite"
+    error: 'Nombre positif requis',
+
+    // Confirm dialog
+    confirm: {
+      header: 'Commander un Devis',
+      refresh: {
+        message:
+          'Les taux du marché seront automatiquement actualisés tous les',
+        unit: 'seconds'
+      },
+      purchase: 'Acheter',
+      transaction: 'Frais de transaction',
+      error: {
+        quote: 'Erreur lors de la récupération du devis',
+        trade: 'Erreur lors de la confirmation de léchange'
+      }
+    }
+  }
 };

--- a/src/shared/services/quote/quote.service.ts
+++ b/src/shared/services/quote/quote.service.ts
@@ -41,7 +41,7 @@ export class QuoteService {
     side: PostQuoteBankModel.SideEnum,
     asset: AssetBankModel,
     counterAsset: AssetBankModel
-  ): PostQuoteBankModel {
+  ): any {
     const symbol = symbolBuild(asset.code, counterAsset.code);
     let postQuoteBankModel: PostQuoteBankModel = {
       customer_guid: this.customer_guid,

--- a/src/shared/services/quote/quote.service.ts
+++ b/src/shared/services/quote/quote.service.ts
@@ -41,7 +41,7 @@ export class QuoteService {
     side: PostQuoteBankModel.SideEnum,
     asset: AssetBankModel,
     counterAsset: AssetBankModel
-  ): any {
+  ): PostQuoteBankModel {
     const symbol = symbolBuild(asset.code, counterAsset.code);
     let postQuoteBankModel: PostQuoteBankModel = {
       customer_guid: this.customer_guid,


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [X] Feature
- [ ] Bug fix

### Linked issue
https://cybrid.atlassian.net/browse/CYB-434

### Why
The next step in the trade component.

### How
This dialog creates a quote and displays it to the client. It automatically refreshes and contains a CTA to confirm the trade.

<img width="704" alt="Screen Shot 2022-06-22 at 12 08 42 PM" src="https://user-images.githubusercontent.com/5817894/175080557-f42e6bcb-a759-445e-8a69-000379a29b44.png">

<img width="714" alt="Screen Shot 2022-06-22 at 12 09 06 PM" src="https://user-images.githubusercontent.com/5817894/175080571-95aa5e93-03ff-4ebb-b06c-4b7e851d3fc5.png">