### PR TITLE
feat: trade component dark mode and style cleanup

### DIFF
--- a/library/src/app/components/price-list/price-list.component.scss
+++ b/library/src/app/components/price-list/price-list.component.scss
@@ -10,6 +10,7 @@ table {
   width: 100%;
   border: 1px solid #0000001f;
   border-radius: 5px;
+
   .mat-column-price {
     width: 80px;
   }
@@ -20,7 +21,7 @@ table {
     border-top-right-radius: 5px;
     text-align: end;
   }
-  > * tr:last-of-type {
+  tr:last-of-type {
     td {
       border-bottom: none;
     }

--- a/library/src/app/components/price-list/price-list.component.ts
+++ b/library/src/app/components/price-list/price-list.component.ts
@@ -3,8 +3,7 @@ import {
   ChangeDetectorRef,
   Component,
   OnDestroy,
-  OnInit,
-  ViewEncapsulation
+  OnInit
 } from '@angular/core';
 import {
   BehaviorSubject,
@@ -38,7 +37,7 @@ import {
   ConfigService
 } from '../../../../../src/shared/services/config/config.service';
 import { AssetService } from '../../../../../src/shared/services/asset/asset.service';
-import { NavigationExtras, Router } from '@angular/router';
+import { Router } from '@angular/router';
 
 export interface SymbolPrice extends SymbolPriceBankModel {
   asset: AssetBankModel;
@@ -48,8 +47,7 @@ export interface SymbolPrice extends SymbolPriceBankModel {
 @Component({
   selector: 'app-list',
   templateUrl: 'price-list.component.html',
-  styleUrls: ['price-list.component.scss'],
-  encapsulation: ViewEncapsulation.None
+  styleUrls: ['price-list.component.scss']
 })
 export class PriceListComponent implements OnInit, AfterViewChecked, OnDestroy {
   config$ = this.configService.getConfig$();

--- a/library/src/app/components/trade-summary/trade-summary.component.html
+++ b/library/src/app/components/trade-summary/trade-summary.component.html
@@ -1,154 +1,153 @@
-<div
-  [ngClass]="{
+<div class="wrapper">
+  <div
+    [ngClass]="{
     'cybrid-dark-theme': (configService.config$ | async)?.theme === 'DARK'
   }"
->
-  <ng-container *ngIf="(isRecoverable$ | async) !== false; else error">
-    <ng-container *ngIf="trade$ | async as trade; else loading">
-      <h2 mat-dialog-title>{{ 'trade.summary.header' | translate }}</h2>
-      <mat-dialog-content>
-        <p class="mat-hint">
-          {{ 'trade.summary.message' | translate }}
-        </p>
-        <ng-container *ngIf="trade.side === 'buy'">
-          <div class="subheader-item list-item">
-            <div class="inner">
-              <span class="mat-body-strong">Transaction ID:</span>
-              <span
-                class="transaction-id"
-                matTooltip="{{ trade.guid }}"
-                matTooltipPosition="above"
-                >{{ trade.guid! | truncate: 9 }}</span
-              >
+  >
+    <ng-container *ngIf="(isRecoverable$ | async) !== false; else error">
+      <ng-container *ngIf="trade$ | async as trade; else loading">
+        <h2 mat-dialog-title>{{ 'trade.summary.header' | translate }}</h2>
+        <mat-dialog-content>
+          <p class="mat-hint">
+            {{ 'trade.summary.message' | translate }}
+          </p>
+          <ng-container *ngIf="trade.side === 'buy'">
+            <div class="subheader-item list-item">
+              <div class="inner">
+                <span class="mat-body-strong">Transaction ID:</span>
+                <span matTooltip="{{ trade.guid }}" matTooltipPosition="above">{{
+                  trade.guid! | truncate: 9
+                  }}</span>
+              </div>
+              <div class="inner">
+                <span class="mat-body-strong">Date:</span>
+                <span>{{ trade.created_at | date }}</span>
+              </div>
             </div>
-            <div class="inner">
-              <span class="mat-body-strong">Date:</span>
-              <span>{{ trade.created_at | date }}</span>
-            </div>
-          </div>
-          <div class="list-item">
+            <div class="list-item">
             <span>
               {{
-                ('trade.summary.purchased' | translate) +
-                  ' ' +
-                  ('trade.amount' | translate)
+              ('trade.summary.purchased' | translate) +
+              ' ' +
+              ('trade.amount' | translate)
               }}
             </span>
-            <div>
+              <div>
               <span>
                 {{ (trade.deliver_amount! | asset: data.counter_asset) + ' ' }}
               </span>
-              <span class="mat-hint">{{ data.counter_asset.code }}</span>
+                <span class="mat-hint">{{ data.counter_asset.code }}</span>
+              </div>
             </div>
-          </div>
-          <mat-divider></mat-divider>
-          <div class="list-item">
+            <mat-divider></mat-divider>
+            <div class="list-item">
             <span
-              >{{
-                ('trade.summary.purchased' | translate) +
-                  ' ' +
-                  ('trade.quantity' | translate)
+            >{{
+              ('trade.summary.purchased' | translate) +
+              ' ' +
+              ('trade.quantity' | translate)
               }}
             </span>
-            <div>
+              <div>
               <span>{{
                 (trade.receive_amount! | asset: data.asset:'trade') + ' '
-              }}</span>
-              <span class="mat-hint">{{ data.asset.code }}</span>
+                }}</span>
+                <span class="mat-hint">{{ data.asset.code }}</span>
+              </div>
             </div>
-          </div>
-          <mat-divider></mat-divider>
-          <div class="list-item">
-            <span>{{ 'trade.transaction' | translate }}</span>
-            <div>
+            <mat-divider></mat-divider>
+            <div class="list-item">
+              <span>{{ 'trade.transaction' | translate }}</span>
+              <div>
               <span>
                 {{ (trade.fee! | asset: data.counter_asset:'trade') + ' ' }}
               </span>
-              <span class="mat-hint">{{ data.counter_asset.code }}</span>
+                <span class="mat-hint">{{ data.counter_asset.code }}</span>
+              </div>
             </div>
-          </div>
-          <mat-divider></mat-divider>
-        </ng-container>
-        <ng-container *ngIf="trade.side === 'sell'">
-          <div class="subheader-item list-item">
-            <div class="inner">
-              <span class="mat-body-strong">Transaction ID:</span>
-              <span
-                class="transaction-id"
-                matTooltip="{{ trade.guid }}"
-                matTooltipPosition="above"
+            <mat-divider></mat-divider>
+          </ng-container>
+          <ng-container *ngIf="trade.side === 'sell'">
+            <div class="subheader-item list-item">
+              <div class="inner">
+                <span class="mat-body-strong">Transaction ID:</span>
+                <span
+                  class="transaction-id"
+                  matTooltip="{{ trade.guid }}"
+                  matTooltipPosition="above"
                 >{{ trade.guid! | truncate: 9 }}</span
-              >
+                >
+              </div>
+              <div class="inner">
+                <span class="mat-body-strong">Date:</span>
+                <span>{{ trade.created_at | date }}</span>
+              </div>
             </div>
-            <div class="inner">
-              <span class="mat-body-strong">Date:</span>
-              <span>{{ trade.created_at | date }}</span>
-            </div>
-          </div>
-          <div class="list-item">
+            <div class="list-item">
             <span>
               {{
-                ('trade.summary.sold' | translate) +
-                  ' ' +
-                  ('trade.amount' | translate)
+              ('trade.summary.sold' | translate) +
+              ' ' +
+              ('trade.amount' | translate)
               }}
             </span>
-            <div>
+              <div>
               <span>
                 {{ (trade.receive_amount! | asset: data.counter_asset) + ' ' }}
               </span>
-              <span class="mat-hint">{{ data.counter_asset.code }}</span>
+                <span class="mat-hint">{{ data.counter_asset.code }}</span>
+              </div>
             </div>
-          </div>
-          <mat-divider></mat-divider>
-          <div class="list-item">
+            <mat-divider></mat-divider>
+            <div class="list-item">
             <span
-              >{{
-                ('trade.summary.sold' | translate) +
-                  ' ' +
-                  ('trade.quantity' | translate)
+            >{{
+              ('trade.summary.sold' | translate) +
+              ' ' +
+              ('trade.quantity' | translate)
               }}
             </span>
-            <div>
+              <div>
               <span>{{
                 (trade.deliver_amount! | asset: data.asset:'trade') + ' '
-              }}</span>
-              <span class="mat-hint">{{ data.asset.code }}</span>
+                }}</span>
+                <span class="mat-hint">{{ data.asset.code }}</span>
+              </div>
             </div>
-          </div>
-          <mat-divider></mat-divider>
-          <div class="list-item">
-            <span>{{ 'trade.transaction' | translate }}</span>
-            <div>
+            <mat-divider></mat-divider>
+            <div class="list-item">
+              <span>{{ 'trade.transaction' | translate }}</span>
+              <div>
               <span>
                 {{ (trade.fee! | asset: data.counter_asset:'trade') + ' ' }}
               </span>
-              <span class="mat-hint">{{ data.counter_asset.code }}</span>
+                <span class="mat-hint">{{ data.counter_asset.code }}</span>
+              </div>
             </div>
-          </div>
-          <mat-divider></mat-divider>
-        </ng-container>
-      </mat-dialog-content>
-      <mat-dialog-actions align="end">
-        <button mat-stroked-button [mat-dialog-close] (click)="onDialogClose()">
-          {{ 'done' | translate }}
-        </button>
-      </mat-dialog-actions>
+            <mat-divider></mat-divider>
+          </ng-container>
+        </mat-dialog-content>
+        <mat-dialog-actions align="end">
+          <button mat-stroked-button [mat-dialog-close] (click)="onDialogClose()">
+            {{ 'done' | translate }}
+          </button>
+        </mat-dialog-actions>
+      </ng-container>
     </ng-container>
-  </ng-container>
-  <ng-template #loading>
-    <div class="loading-wrapper">
-      <h2>{{ 'trade.summary.loading' | translate }}</h2>
-      <mat-spinner diameter="40"></mat-spinner>
-    </div>
-  </ng-template>
-  <ng-template #error>
-    <mat-card>
-      <mat-card-content>
-        <div class="fatal">
-          <p>{{ 'fatal' | translate }}</p>
-        </div>
-      </mat-card-content>
-    </mat-card>
-  </ng-template>
+    <ng-template #loading>
+      <div class="loading-wrapper">
+        <h2>{{ 'trade.summary.loading' | translate }}</h2>
+        <mat-spinner diameter="40"></mat-spinner>
+      </div>
+    </ng-template>
+    <ng-template #error>
+      <mat-card>
+        <mat-card-content>
+          <div class="fatal">
+            <p>{{ 'fatal' | translate }}</p>
+          </div>
+        </mat-card-content>
+      </mat-card>
+    </ng-template>
+  </div>
 </div>

--- a/library/src/app/components/trade-summary/trade-summary.component.scss
+++ b/library/src/app/components/trade-summary/trade-summary.component.scss
@@ -2,6 +2,10 @@
 @import url('https://fonts.googleapis.com/icon?family=Material+Icons');
 @import '../../../../../src/shared/styles/theme.scss';
 
+.wrapper {
+  display: flex;
+}
+
 .list-item {
   min-height: 3rem;
   display: flex;
@@ -19,8 +23,5 @@
     display: flex;
     flex-direction: column;
     flex-grow: 1;
-    .transaction-id {
-      cursor: pointer;
-    }
   }
 }

--- a/library/src/app/components/trade/trade.component.html
+++ b/library/src/app/components/trade/trade.component.html
@@ -5,6 +5,12 @@
 >
   <ng-container *ngIf="(isRecoverable$ | async) !== false; else error">
     <ng-container *ngIf="(isLoading$ | async) !== true">
+      <button mat-button color="primary" routerLink="..">
+        <div class="navigation">
+          <mat-icon>arrow_back</mat-icon>
+          <div>{{ 'back' | translate }}</div>
+        </div>
+      </button>
       <mat-tab-group
         animationDuration="0ms"
         (selectedTabChange)="onSwitchSide($event.tab.origin)"
@@ -14,95 +20,102 @@
       </mat-tab-group>
       <ng-container [formGroup]="quoteGroup">
         <div class="tab-wrapper">
-          <mat-form-field appearance="outline">
-            <mat-label>{{ 'trade.currency' | translate }}</mat-label>
-            <mat-select
-              #matSelect
-              [compareWith]="compareObjects"
-              formControlName="asset"
-            >
-              <mat-select-trigger>
-                <div class="option">
-                  <img
-                    class="select-icon"
-                    src="{{ matSelect.value.url }}"
-                    alt="Crypto currency icon"
-                  />
-                  <span class="asset-name">{{ matSelect.value.name }}</span>
-                </div>
-              </mat-select-trigger>
-              <mat-option *ngFor="let asset of cryptoAssets" [value]="asset">
-                <div class="option">
-                  <img
-                    class="icon"
-                    src="{{ asset.url }}"
-                    alt="Crypto currency icon"
-                  />
-                  <span class="asset-name">{{ asset.name }}</span>
-                </div>
-              </mat-option>
-            </mat-select>
-          </mat-form-field>
-          <mat-form-field appearance="outline">
-            <mat-label>
-              <span>{{ 'trade.amount' | translate | titlecase }}</span>
-            </mat-label>
-            <input
-              matInput
-              #amount="matInput"
-              formControlName="amount"
-              type="number"
-              min="0"
-              placeholder="0"
-              [ngClass]="{ input: amount.value }"
-            />
-            <div *ngIf="amount.value" class="display-code prefix" matPrefix>
-              {{ input === 'asset' ? asset.code : counterAsset.code }}
-              <div class="divider"></div>
-            </div>
-            <button
-              *ngIf="amount.value"
-              mat-icon-button
-              matSuffix
-              (click)="quoteGroup.get('amount')?.reset()"
-            >
-              <mat-icon>close</mat-icon>
-            </button>
-            <mat-error>{{ 'trade.error' | translate }}</mat-error>
-          </mat-form-field>
-          <div class="hint">
-            <ng-container *ngIf="!amount.value">
-              <span> 1 </span>
-              <span class="display-code">
-                {{ asset.code }}
-              </span>
-              <span>=</span>
-              <span>
-                {{ price.buy_price! | asset: counterAsset:'trade' | currency }}
-              </span>
-              <span class="display-code">{{ ' ' + counterAsset.code }}</span>
-            </ng-container>
-            <ng-container *ngIf="amount.value">
-              <img
-                *ngIf="input === 'asset'"
-                class="display-icon"
-                alt="Fiat asset national flag"
-                src="{{ counterAsset.url }}"
+          <div class="input-wrapper">
+            <mat-form-field appearance="outline">
+              <mat-label>{{ 'trade.currency' | translate }}</mat-label>
+              <mat-select
+                #matSelect
+                [compareWith]="compareObjects"
+                formControlName="asset"
+              >
+                <mat-select-trigger>
+                  <div class="option">
+                    <img
+                      class="select-icon"
+                      src="{{ matSelect.value.url }}"
+                      alt="Crypto currency icon"
+                    />
+                    <span class="asset-name">{{ matSelect.value.name }}</span>
+                  </div>
+                </mat-select-trigger>
+                <mat-option *ngFor="let asset of cryptoAssets" [value]="asset">
+                  <div class="option">
+                    <img
+                      class="display-icon"
+                      src="{{ asset.url }}"
+                      alt="Crypto currency icon"
+                    />
+                    <span>{{ asset.name }}</span>
+                  </div>
+                </mat-option>
+              </mat-select>
+            </mat-form-field>
+            <mat-form-field appearance="outline">
+              <mat-label>
+                <span>{{ 'trade.amount' | translate | titlecase }}</span>
+              </mat-label>
+              <input
+                matInput
+                #amount="matInput"
+                formControlName="amount"
+                type="number"
+                min="0"
+                placeholder="0"
+                [ngClass]="{ input: amount.value }"
               />
-              <span>
-                {{
-                  input === 'asset'
-                    ? (display.counter_asset | asset: counterAsset)
-                    : display.asset
-                }}
-              </span>
-              <span class="display-code">
-                {{ input === 'asset' ? counterAsset.code : asset.code }}
-              </span>
-            </ng-container>
-            <button mat-icon-button color="primary" (click)="onSwitchInput()">
-              <mat-icon>swap_vert</mat-icon>
-            </button>
+              <div *ngIf="amount.value" class="display-code prefix" matPrefix>
+                {{ input === 'asset' ? asset.code : counterAsset.code }}
+                <div class="divider"></div>
+              </div>
+              <button
+                *ngIf="amount.value"
+                mat-icon-button
+                matSuffix
+                (click)="quoteGroup.get('amount')?.reset()"
+              >
+                <mat-icon>close</mat-icon>
+              </button>
+              <mat-error>{{ 'trade.error' | translate }}</mat-error>
+            </mat-form-field>
+          </div>
+          <div class="hint-wrapper">
+            <div class="spacer"></div>
+            <div class="hint">
+              <ng-container *ngIf="!amount.value">
+                <span> 1 </span>
+                <span class="display-code">
+                  {{ asset.code }}
+                </span>
+                <span>=</span>
+                <span>
+                  {{
+                    price.buy_price! | asset: counterAsset:'trade' | currency
+                  }}
+                </span>
+                <span class="display-code">{{ ' ' + counterAsset.code }}</span>
+              </ng-container>
+              <ng-container *ngIf="amount.value">
+                <img
+                  *ngIf="input === 'asset'"
+                  class="display-icon"
+                  alt="Fiat asset national flag"
+                  src="{{ counterAsset.url }}"
+                />
+                <span>
+                  {{
+                    input === 'asset'
+                      ? (display.counter_asset | asset: counterAsset)
+                      : display.asset
+                  }}
+                </span>
+                <span class="display-code">
+                  {{ input === 'asset' ? counterAsset.code : asset.code }}
+                </span>
+              </ng-container>
+              <button mat-icon-button color="primary" (click)="onSwitchInput()">
+                <mat-icon>swap_vert</mat-icon>
+              </button>
+            </div>
           </div>
           <button
             class="action"
@@ -113,7 +126,7 @@
               !quoteGroup.valid || !(amount.value.toString().length > 0)
             "
           >
-            {{ 'trade.' + side.toString() | translate | titlecase }}
+            {{ 'trade.' + side.toString() | translate | uppercase }}
           </button>
         </div>
       </ng-container>

--- a/library/src/app/components/trade/trade.component.scss
+++ b/library/src/app/components/trade/trade.component.scss
@@ -9,6 +9,12 @@
   margin-top: calc(1rem + 0.25em);
 }
 
+.input-wrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
 .select-code {
   @extend .mat-hint;
   @extend .mat-h5;
@@ -88,4 +94,32 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
+}
+
+// XL (extra-large)
+@media screen and (min-width: 1535px) {
+  .hint-wrapper {
+    display: flex;
+    gap: 1rem;
+    .spacer {
+      flex: 1;
+    }
+    .hint {
+      flex: 1;
+      button {
+        margin-left: auto;
+      }
+    }
+  }
+  mat-form-field {
+    flex: 1;
+  }
+  .input-wrapper {
+    flex-direction: row;
+    gap: 1rem;
+  }
+  .action {
+    align-self: center;
+    width: 320px;
+  }
 }

--- a/src/demo/components/app/app.component.html
+++ b/src/demo/components/app/app.component.html
@@ -1,16 +1,27 @@
-<mat-toolbar color="primary">
-  <img
-    src="https://assets-global.website-files.com/6226732e4130814a4adb86c2/62430bcedab2d5494d20b601_logo-white.svg"
-    alt="Cybrid logo"
-  />
-  <div class="spacer"></div>
-  <a
-    class="package"
-    href="https://www.npmjs.com/package/@cybrid/cybrid-sdk-ui-js"
-    >{{ 'cybrid-sdk-ui-js@ ' + (version | async) }}</a
-  >
-</mat-toolbar>
-
-<div class="wrapper">
-  <app-demo></app-demo>
+<div
+  class="wrapper"
+  [ngClass]="{
+    'cybrid-dark-theme': (configService.config$ | async)?.theme === 'DARK'
+  }"
+>
+  <mat-toolbar color="primary">
+    <img
+      src="https://assets-global.website-files.com/6226732e4130814a4adb86c2/62430bcedab2d5494d20b601_logo-white.svg"
+      alt="Cybrid logo"
+    />
+    <div class="spacer"></div>
+    <a
+      class="mat-body package"
+      href="https://www.npmjs.com/package/@cybrid/cybrid-sdk-ui-js"
+      >{{ 'cybrid-sdk-ui-js@ ' + (version | async) }}</a
+    >
+    <button mat-icon-button>
+      <mat-icon (click)="toggleTheme()">{{ mode }}</mat-icon>
+    </button>
+  </mat-toolbar>
+  <mat-drawer-container>
+    <mat-drawer-content>
+      <app-demo></app-demo>
+    </mat-drawer-content>
+  </mat-drawer-container>
 </div>

--- a/src/demo/components/app/app.component.scss
+++ b/src/demo/components/app/app.component.scss
@@ -3,10 +3,25 @@
 mat-toolbar {
   display: flex;
   align-items: center;
+  gap: 0.5rem;
   @include mat.elevation(2);
-  > a {
-    font-size: 1rem;
-  }
+}
+
+mat-drawer-container {
+  flex-grow: 1;
+}
+
+mat-drawer-content {
+  max-width: 700px;
+  margin: auto;
+  padding: 2rem 1rem 1rem;
+}
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  height: 100vh;
 }
 
 .spacer {
@@ -17,13 +32,4 @@ mat-toolbar {
   margin-left: auto;
   color: white;
   text-decoration: none;
-}
-.wrapper {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 1rem;
-  max-width: 700px;
-  margin: auto;
-  padding: 2rem 1rem 1rem;
 }

--- a/src/demo/components/app/app.component.scss
+++ b/src/demo/components/app/app.component.scss
@@ -21,6 +21,7 @@ mat-drawer-content {
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  overflow-x: hidden;
   height: 100vh;
 }
 

--- a/src/demo/components/app/app.component.ts
+++ b/src/demo/components/app/app.component.ts
@@ -11,11 +11,30 @@ import { Constants } from '../../../shared/constants/constants';
 })
 export class AppComponent {
   version: Observable<string> = new Observable<string>();
+  mode: 'light_mode' | 'dark_mode' = 'light_mode';
 
   constructor(private http: HttpClient, public configService: ConfigService) {
     this.version = this.http.get(Constants.REPO_URL).pipe(
       pluck('tag_name'),
       map((tag) => tag as string)
     );
+  }
+
+  toggleTheme(): void {
+    const config = this.configService.config;
+    switch (this.mode) {
+      case 'light_mode': {
+        this.mode = 'dark_mode';
+        config.theme = 'DARK';
+        this.configService.config$.next(config);
+        break;
+      }
+      case 'dark_mode': {
+        this.mode = 'light_mode';
+        config.theme = 'LIGHT';
+        this.configService.config$.next(config);
+        break;
+      }
+    }
   }
 }

--- a/src/demo/components/demo/demo.component.ts
+++ b/src/demo/components/demo/demo.component.ts
@@ -1,41 +1,60 @@
-import { Component, OnInit, ViewChild, ViewContainerRef } from '@angular/core';
+import {
+  Component,
+  ComponentRef,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+  ViewContainerRef
+} from '@angular/core';
 import { AppComponent } from '../../../../library/src/app/components/app/app.component';
 import { ConfigService } from '../../services/config/config.service';
-import { BehaviorSubject, map, take } from 'rxjs';
+import { BehaviorSubject, map, Subject, take, takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-demo',
   templateUrl: './demo.component.html',
   styleUrls: ['./demo.component.scss']
 })
-export class DemoComponent implements OnInit {
+export class DemoComponent implements OnInit, OnDestroy {
   @ViewChild('viewContainer', { static: true, read: ViewContainerRef })
   public viewContainer!: ViewContainerRef;
+  token = '';
+
+  componentRef!: ComponentRef<AppComponent>;
   loading$ = new BehaviorSubject(true);
 
-  constructor(public tokenService: ConfigService) {}
+  private unsubscribe$ = new Subject();
+
+  constructor(
+    public tokenService: ConfigService,
+    public configService: ConfigService
+  ) {}
 
   ngOnInit(): void {
-    this.initDemo();
-  }
-
-  initDemo() {
     this.tokenService.token$
       .pipe(
         take(1),
-        map((token) => {
-          const elementRef = this.viewContainer.createComponent(AppComponent);
-          elementRef.instance.auth = token;
-          elementRef.instance.hostConfig = {
-            refreshInterval: 2000,
-            locale: 'en-US',
-            theme: 'LIGHT',
-            customer: ''
-          };
-        })
+        map((token) => (this.token = token))
       )
       .subscribe(() => {
-        this.loading$.next(false);
+        this.initDemo();
+      });
+  }
+
+  ngOnDestroy() {
+    this.unsubscribe$.next('');
+    this.unsubscribe$.complete();
+  }
+
+  initDemo() {
+    this.componentRef = this.viewContainer.createComponent(AppComponent);
+    this.componentRef.instance.auth = this.token;
+    this.loading$.next(false);
+
+    this.configService.config$
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((config) => {
+        this.componentRef.instance.hostConfig = config;
       });
   }
 }

--- a/src/demo/services/config/config.service.ts
+++ b/src/demo/services/config/config.service.ts
@@ -15,6 +15,7 @@ import {
   tap
 } from 'rxjs';
 import { environment } from '../../../environments/environment';
+import { ComponentConfig } from '../../../shared/services/config/config.service';
 
 @Injectable({
   providedIn: 'root'
@@ -22,6 +23,14 @@ import { environment } from '../../../environments/environment';
 export class ConfigService {
   token$ = new Subject<string>();
   invalidCredentials$ = new BehaviorSubject(false);
+  config: ComponentConfig = {
+    refreshInterval: 5000,
+    locale: 'en-US',
+    theme: 'LIGHT',
+    customer: ''
+  };
+  config$ = new BehaviorSubject<ComponentConfig>(this.config);
+
   constructor(private http: HttpClient) {
     this.createToken()
       .pipe(

--- a/src/shared/i18n/en.ts
+++ b/src/shared/i18n/en.ts
@@ -1,8 +1,9 @@
 export default {
   // General
-  cancel: 'Cancel',
-  confirm: 'Confirm',
-  done: 'Done',
+  cancel: 'CANCEL',
+  confirm: 'CONFIRM',
+  done: 'DONE',
+  back: 'Back',
   date: 'Date',
   fatal: 'An unrecoverable error occurred',
 
@@ -24,8 +25,8 @@ export default {
     amount: 'amount',
     quantity: 'quantity',
     currency: 'Currency',
-    buy: 'Buy',
-    sell: 'Sell',
+    buy: 'BUY',
+    sell: 'SELL',
     error: 'Positive number required',
     transaction: 'Transaction fee',
 
@@ -45,7 +46,7 @@ export default {
 
     // Summary dialog
     summary: {
-      header: 'Order Finalized',
+      header: 'Order Submitted',
       message: 'Your order has been placed, thank you.',
       purchased: 'Purchased',
       sold: 'Sold',

--- a/src/shared/i18n/fr.ts
+++ b/src/shared/i18n/fr.ts
@@ -1,8 +1,9 @@
 export default {
   // General
-  cancel: 'Annuler',
-  confirm: 'Confirmer',
-  done: 'Fait',
+  cancel: 'ANNULER',
+  confirm: 'CONFIRMER',
+  done: 'FAIT',
+  back: 'Retourner',
   date: 'Date',
   fatal: "Une erreur irrécupérable s'est produite",
 
@@ -24,8 +25,8 @@ export default {
     amount: 'montant',
     quantity: 'quantité',
     currency: 'Devise',
-    buy: 'Acheter',
-    sell: 'Vendre',
+    buy: 'ACHETER',
+    sell: 'VENDRE ',
     error: 'Nombre positif requis',
     transaction: 'Frais de transaction',
 
@@ -46,7 +47,7 @@ export default {
 
     // Summary dialog
     summary: {
-      header: 'Commande Finalisée',
+      header: 'Commande Soumise',
       message: 'Votre commande a été passée, merci.',
       purchased: 'Acheté',
       sold: 'Vendu',

--- a/src/shared/services/config/config.service.spec.ts
+++ b/src/shared/services/config/config.service.spec.ts
@@ -80,5 +80,11 @@ describe('ConfigService', () => {
     config.subscribe((cfg) => {
       expect(cfg).toEqual(testConfig);
     });
+    const darkTestConfig = testConfig;
+    darkTestConfig.theme = 'DARK';
+    service.setConfig(darkTestConfig);
+    config.subscribe((cfg) => {
+      expect(cfg).toEqual(darkTestConfig);
+    });
   });
 });

--- a/src/shared/services/config/config.service.spec.ts
+++ b/src/shared/services/config/config.service.spec.ts
@@ -80,10 +80,17 @@ describe('ConfigService', () => {
     config.subscribe((cfg) => {
       expect(cfg).toEqual(testConfig);
     });
-    const darkTestConfig = testConfig;
-    darkTestConfig.theme = 'DARK';
+  });
+
+  it('should set light and dark mode', () => {
+    const darkTestConfig: ComponentConfig = {
+      refreshInterval: 5000,
+      locale: 'en-US',
+      theme: 'DARK',
+      customer: ''
+    };
     service.setConfig(darkTestConfig);
-    config.subscribe((cfg) => {
+    service.config$.subscribe((cfg) => {
       expect(cfg).toEqual(darkTestConfig);
     });
   });

--- a/src/shared/styles/theme.scss
+++ b/src/shared/styles/theme.scss
@@ -144,8 +144,8 @@ $cybrid-dark-accent-palette: (
   )
 );
 
-$dark-primary: mat.define-palette(mat.$pink-palette, 500);
-$dark-accent: mat.define-palette(mat.$blue-gray-palette, A200, A100, A400);
+$dark-primary: mat.define-palette(mat.$purple-palette, 500);
+$dark-accent: mat.define-palette(mat.$green-palette, A200, A100, A400);
 $dark-warn: mat.define-palette(mat.$red-palette);
 
 $dark-theme: mat.define-dark-theme(
@@ -176,14 +176,16 @@ $light-theme: mat.define-light-theme(
 
 .cybrid-dark-theme {
   @include mat.all-component-colors($dark-theme);
-  color: white;
+
+  // Material select not selected option color
+  .mat-option:not(.mat-selected) {
+    color: white;
+  }
 }
 
 html,
 body {
   height: 100%;
-}
-body {
   margin: 0;
   font-family: Roboto, 'Helvetica Neue', sans-serif;
 }
@@ -199,6 +201,20 @@ input[type='number']::-webkit-outer-spin-button {
   display: flex;
   flex-direction: column;
   align-items: center;
+}
+
+.navigation {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 400;
+  mat-icon {
+    height: 1rem;
+    width: 1rem;
+    line-height: 1rem;
+    font-size: 1rem;
+  }
 }
 
 // Material style overrides


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [X] Feature
- [ ] Bug fix

### Linked issue
https://cybrid.atlassian.net/browse/CYB-437

### Why
Dark mode styles were not being applied to mat-select and mat-dialog components.

### How
By extending the `ConfigService` to apply the dark mode class when `theme: 'DARK'`.
Also included are some general style updates.