### PR TITLE
fix: convert bank client number types to string

### DIFF
--- a/library/src/app/components/trade/trade.component.spec.ts
+++ b/library/src/app/components/trade/trade.component.spec.ts
@@ -184,8 +184,8 @@ describe('TradeComponent', () => {
   });
 
   it('should get prices', () => {
-    component.price.buy_price = 1;
-    component.price.sell_price = 1;
+    component.price.buy_price = '1';
+    component.price.sell_price = '1';
     component.initQuoteGroup();
     component.quoteGroup.patchValue({
       amount: 1,

--- a/library/src/app/components/trade/trade.component.spec.ts
+++ b/library/src/app/components/trade/trade.component.spec.ts
@@ -198,7 +198,12 @@ describe('TradeComponent', () => {
     component.input = 'counter_asset';
     component.getPrice();
     expect(component.display.asset).toEqual(100000000);
-    expect(component.display.counter_asset).toEqual(100000000);
+
+    /*
+     * If the input is 'counter_asset' the base value returned from the asset pipe will
+     * be of type 'string' to disable scientific notation for api calls
+     * */
+    expect(component.display.counter_asset).toEqual('100000000');
 
     component.side = 'sell';
     component.input = 'asset';
@@ -209,7 +214,7 @@ describe('TradeComponent', () => {
     component.input = 'counter_asset';
     component.getPrice();
     expect(component.display.asset).toEqual(100000000);
-    expect(component.display.counter_asset).toEqual(100000000);
+    expect(component.display.counter_asset).toEqual('100000000');
 
     MockPricesService.listPrices.and.returnValue(error$);
     component.getPrice();

--- a/library/src/app/components/trade/trade.component.ts
+++ b/library/src/app/components/trade/trade.component.ts
@@ -44,6 +44,11 @@ import { Constants } from '../../../../../src/shared/constants/constants';
 import SideEnum = PostQuoteBankModel.SideEnum;
 import { RoutingService } from '../../../../../src/shared/services/routing/routing.service';
 
+interface Display {
+  asset: number | string;
+  counter_asset: number | string;
+}
+
 @Component({
   selector: 'app-trade',
   templateUrl: './trade.component.html',
@@ -69,7 +74,7 @@ export class TradeComponent implements OnInit, OnDestroy {
     amount: new FormControl()
   });
 
-  display = {
+  display: Display = {
     asset: 0,
     counter_asset: 0
   };
@@ -173,6 +178,12 @@ export class TradeComponent implements OnInit, OnDestroy {
         map((priceArray) => {
           this.price = priceArray[0];
 
+          // Set amount to 0 if null
+          const amount = this.quoteGroup.get('amount')?.value;
+          if (amount == null) {
+            this.amount = 0;
+          }
+
           switch (this.input) {
             case 'asset': {
               const sidePrice =
@@ -253,7 +264,6 @@ export class TradeComponent implements OnInit, OnDestroy {
         break;
       }
     }
-    this.getPrice();
   }
 
   onSwitchSide(tab: number | null): void {

--- a/library/src/app/components/trade/trade.component.ts
+++ b/library/src/app/components/trade/trade.component.ts
@@ -188,8 +188,8 @@ export class TradeComponent implements OnInit, OnDestroy {
             case 'asset': {
               const sidePrice =
                 this.side == 'buy'
-                  ? this.price.sell_price
-                  : this.price.buy_price;
+                  ? Number(this.price.sell_price)
+                  : Number(this.price.buy_price);
               this.display.asset = this.amount;
               this.display.counter_asset = this.amount * sidePrice!;
               break;
@@ -197,8 +197,8 @@ export class TradeComponent implements OnInit, OnDestroy {
             case 'counter_asset': {
               const sidePrice =
                 this.side == 'buy'
-                  ? this.price.buy_price
-                  : this.price.sell_price;
+                  ? Number(this.price.buy_price)
+                  : Number(this.price.sell_price);
               let baseValue = this.assetPipe.transform(
                 this.amount,
                 this.counterAsset,
@@ -264,6 +264,7 @@ export class TradeComponent implements OnInit, OnDestroy {
         break;
       }
     }
+    this.getPrice();
   }
 
   onSwitchSide(tab: number | null): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@angular/platform-browser": "14.0.6",
         "@angular/platform-browser-dynamic": "14.0.6",
         "@angular/router": "14.0.6",
-        "@cybrid/cybrid-api-bank-angular": "0.32.1",
+        "@cybrid/cybrid-api-bank-angular": "0.32.2",
         "@ngx-translate/core": "14.0.0",
         "@ngx-translate/http-loader": "^7.0.0",
         "big.js": "6.2.1",
@@ -2994,9 +2994,9 @@
       }
     },
     "node_modules/@cybrid/cybrid-api-bank-angular": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/@cybrid/cybrid-api-bank-angular/-/cybrid-api-bank-angular-0.32.1.tgz",
-      "integrity": "sha512-nT3jKAuHPPwTdc8ty0JBxdY06xrb5ViJGUBzhEm/YpBOSGX+cNh5FVlNSwgtKhLxXQWgK22UXH+BXvtMjDDdPQ==",
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cybrid/cybrid-api-bank-angular/-/cybrid-api-bank-angular-0.32.2.tgz",
+      "integrity": "sha512-8qNE/zMXHtot5/J0N6DBuK8tj+1DnuxNiRHNHXa9ddx1IZRMocukjMNQRzky2nJW8C5hs3BJkobRMDGBBYUbfQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -17945,9 +17945,9 @@
       "requires": {}
     },
     "@cybrid/cybrid-api-bank-angular": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/@cybrid/cybrid-api-bank-angular/-/cybrid-api-bank-angular-0.32.1.tgz",
-      "integrity": "sha512-nT3jKAuHPPwTdc8ty0JBxdY06xrb5ViJGUBzhEm/YpBOSGX+cNh5FVlNSwgtKhLxXQWgK22UXH+BXvtMjDDdPQ==",
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cybrid/cybrid-api-bank-angular/-/cybrid-api-bank-angular-0.32.2.tgz",
+      "integrity": "sha512-8qNE/zMXHtot5/J0N6DBuK8tj+1DnuxNiRHNHXa9ddx1IZRMocukjMNQRzky2nJW8C5hs3BJkobRMDGBBYUbfQ==",
       "requires": {
         "tslib": "^2.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@angular/platform-browser": "14.0.6",
     "@angular/platform-browser-dynamic": "14.0.6",
     "@angular/router": "14.0.6",
-    "@cybrid/cybrid-api-bank-angular": "0.32.1",
+    "@cybrid/cybrid-api-bank-angular": "0.32.2",
     "@ngx-translate/core": "14.0.0",
     "@ngx-translate/http-loader": "^7.0.0",
     "big.js": "6.2.1",

--- a/src/shared/constants/constants.ts
+++ b/src/shared/constants/constants.ts
@@ -25,7 +25,7 @@ export class Constants {
   static BTC_ICON = 'https://images.cybrid.xyz/sdk/assets/svg/color/btc.svg';
   static BTC_ASSET: Asset = {
     code: 'BTC',
-    decimals: 8,
+    decimals: '8',
     name: 'Bitcoin',
     symbol: '₿',
     type: 'crypto',
@@ -33,7 +33,7 @@ export class Constants {
   };
   static USD_ASSET: Asset = {
     code: 'USD',
-    decimals: 2,
+    decimals: '2',
     name: 'Dollar',
     symbol: '$',
     type: 'fiat',

--- a/src/shared/constants/test.constants.ts
+++ b/src/shared/constants/test.constants.ts
@@ -28,7 +28,7 @@ export class TestConstants {
   // Extension of AssetBankModel to include urls
   static BTC_ASSET: Asset = {
     code: 'BTC',
-    decimals: 8,
+    decimals: '8',
     name: 'Bitcoin',
     symbol: '₿',
     type: 'crypto',
@@ -36,7 +36,7 @@ export class TestConstants {
   };
   static ETH_ASSET: Asset = {
     code: 'ETH',
-    decimals: 18,
+    decimals: '18',
     name: 'Ethereum',
     symbol: 'Ξ',
     type: 'crypto',
@@ -44,7 +44,7 @@ export class TestConstants {
   };
   static CAD_ASSET: Asset = {
     code: 'CAD',
-    decimals: 2,
+    decimals: '2',
     name: 'Canadian Dollar',
     symbol: '$',
     type: 'fiat',
@@ -52,7 +52,7 @@ export class TestConstants {
   };
   static USD_ASSET: Asset = {
     code: 'USD',
-    decimals: 2,
+    decimals: '2',
     name: 'United States Dollar',
     symbol: '$',
     type: 'fiat',
@@ -70,15 +70,15 @@ export class TestConstants {
     asset: TestConstants.BTC_ASSET,
     counter_asset: TestConstants.BTC_ASSET,
     symbol: 'BTC-USD',
-    buy_price: 0,
-    sell_price: 0,
+    buy_price: '0',
+    sell_price: '0',
     buy_price_last_updated_at: '',
     sell_price_last_updated_at: ''
   };
   static SYMBOL_PRICE_BANK_MODEL: SymbolPriceBankModel = {
     symbol: 'BTC-CAD',
-    buy_price: 1,
-    sell_price: 1,
+    buy_price: '1',
+    sell_price: '1',
     buy_price_last_updated_at: '',
     sell_price_last_updated_at: ''
   };
@@ -88,16 +88,16 @@ export class TestConstants {
     customer_guid: TestConstants.CUSTOMER_GUID,
     symbol: 'BTC-USD',
     side: 'buy',
-    receive_amount: 100000000
+    receive_amount: '100000000'
   };
   static QUOTE_BANK_MODEL: QuoteBankModel = {
     guid: 'ede5f73db305fbd27ec0eb0894ae8aa7',
     customer_guid: TestConstants.CUSTOMER_GUID,
     symbol: 'ETH-USD',
     side: 'buy',
-    receive_amount: 1000000000000000000,
-    deliver_amount: 103331,
-    fee: 0,
+    receive_amount: '1000000000000000000',
+    deliver_amount: '103331',
+    fee: '0',
     issued_at: '2022-06-30T17:04:37.331Z',
     expires_at: '2022-06-30T17:05:07.331Z'
   };
@@ -111,9 +111,9 @@ export class TestConstants {
     state: 'storing',
     // @ts-ignore
     failure_code: null,
-    receive_amount: 1000000000000000000,
-    deliver_amount: 103331,
-    fee: 0,
+    receive_amount: '1000000000000000000',
+    deliver_amount: '103331',
+    fee: '0',
     created_at: '2022-06-30T17:04:39.049Z'
   };
 }

--- a/src/shared/pipes/asset/asset.pipe.spec.ts
+++ b/src/shared/pipes/asset/asset.pipe.spec.ts
@@ -65,9 +65,10 @@ describe('AssetPipe', () => {
   });
 
   it('should return a base unit when the param is set to base', () => {
+    // 'Base' returns 'string' type
     const pipe = new AssetPipe(MockConfigService);
     expect(pipe.transform(36010, TestConstants.BTC_ASSET, 'base')).toEqual(
-      3601000000000
+      '3601000000000'
     );
   });
 

--- a/src/shared/pipes/asset/asset.pipe.ts
+++ b/src/shared/pipes/asset/asset.pipe.ts
@@ -50,7 +50,7 @@ export class AssetPipe implements PipeTransform, OnDestroy {
     asset: AssetBankModel | Asset,
     unit: 'trade' | 'base' | 'formatted' = 'formatted'
   ): string | number {
-    const divisor = new Big(10).pow(asset.decimals);
+    const divisor = new Big(10).pow(Number(asset.decimals));
     const tradeUnit = new Big(value).div(divisor);
     const baseUnit = new Big(value).mul(divisor);
 

--- a/src/shared/pipes/asset/asset.pipe.ts
+++ b/src/shared/pipes/asset/asset.pipe.ts
@@ -55,12 +55,25 @@ export class AssetPipe implements PipeTransform, OnDestroy {
     const baseUnit = new Big(value).mul(divisor);
 
     switch (unit) {
+      // Whole coin unit without formatting, ex. 0.0023 BTC
       case 'trade': {
         return tradeUnit.toNumber();
       }
+
+      // Base coin unit without formatting, ex. 2000000000 Wei
+      // Type 'string' is returned here to disable scientific notation from JS 'number' Type
       case 'base': {
-        return baseUnit.toNumber();
+        // Set the positive exponent value at and above which toString returns exponential notation.
+        Big.PE = 100;
+
+        let base = baseUnit.toString();
+
+        // Reset
+        Big.PE = 21;
+        return base;
       }
+
+      // Returns a formatted (localized) whole coin unit, ex. 1,230.22 ETH
       case 'formatted': {
         if (tradeUnit.toString().includes('.')) {
           let separator = this.separator.find((value) => {

--- a/src/shared/pipes/asset/asset.pipe.ts
+++ b/src/shared/pipes/asset/asset.pipe.ts
@@ -63,13 +63,15 @@ export class AssetPipe implements PipeTransform, OnDestroy {
       // Base coin unit without formatting, ex. 2000000000 Wei
       // Type 'string' is returned here to disable scientific notation from JS 'number' Type
       case 'base': {
+        const defaultPE = Big.PE;
+
         // Set the positive exponent value at and above which toString returns exponential notation.
         Big.PE = 100;
 
         let base = baseUnit.toString();
 
-        // Reset
-        Big.PE = 21;
+        // Reset to default
+        Big.PE = defaultPE;
         return base;
       }
 

--- a/src/shared/pipes/asset/mock-asset.pipe.ts
+++ b/src/shared/pipes/asset/mock-asset.pipe.ts
@@ -35,7 +35,7 @@ export class MockAssetPipe implements PipeTransform, OnDestroy {
     asset: AssetBankModel | Asset,
     unit: 'trade' | 'base' | 'formatted' = 'formatted'
   ): string | number {
-    const divisor = new Big(10).pow(asset.decimals);
+    const divisor = new Big(10).pow(Number(asset.decimals));
     const tradeUnit = new Big(value).div(divisor);
     const baseUnit = new Big(value).mul(divisor);
 

--- a/src/shared/pipes/asset/mock-asset.pipe.ts
+++ b/src/shared/pipes/asset/mock-asset.pipe.ts
@@ -40,12 +40,25 @@ export class MockAssetPipe implements PipeTransform, OnDestroy {
     const baseUnit = new Big(value).mul(divisor);
 
     switch (unit) {
+      // Whole coin unit without formatting, ex. 0.0023 BTC
       case 'trade': {
         return tradeUnit.toNumber();
       }
+
+      // Base coin unit without formatting, ex. 2000000000 Wei
+      // Type 'string' is returned here to disable scientific notation from JS 'number' Type
       case 'base': {
-        return baseUnit.toNumber();
+        // Set the positive exponent value at and above which toString returns exponential notation.
+        Big.PE = 100;
+
+        let base = baseUnit.toString();
+
+        // Reset
+        Big.PE = 21;
+        return base;
       }
+
+      // Returns a formatted (localized) whole coin unit, ex. 1,230.22 ETH
       case 'formatted': {
         if (tradeUnit.toString().includes('.')) {
           let separator = this.separator.find((value) => {

--- a/src/shared/services/asset/asset.service.spec.ts
+++ b/src/shared/services/asset/asset.service.spec.ts
@@ -23,14 +23,14 @@ describe('AssetService', () => {
     type: 'crypto',
     code: 'ETH',
     name: 'Ethereum',
-    decimals: 18,
+    decimals: '18',
     symbol: '',
     url: Constants.ICON_HOST + 'eth.svg'
   };
   const testAssetList: AssetListBankModel = {
-    total: 0,
-    page: 0,
-    per_page: 0,
+    total: '0',
+    page: '0',
+    per_page: '0',
     objects: [testAssetModel]
   };
   let MockAssetsService = jasmine.createSpyObj('AssetsService', {

--- a/src/shared/services/asset/asset.service.ts
+++ b/src/shared/services/asset/asset.service.ts
@@ -22,7 +22,7 @@ export interface Asset extends AssetBankModel {
   code: string;
   name: string;
   symbol: string;
-  decimals: number;
+  decimals: string;
   url: string;
 }
 

--- a/src/shared/services/error/error.service.spec.ts
+++ b/src/shared/services/error/error.service.spec.ts
@@ -1,11 +1,6 @@
-import {
-  discardPeriodicTasks,
-  fakeAsync,
-  TestBed,
-  tick
-} from '@angular/core/testing';
+import { fakeAsync, TestBed } from '@angular/core/testing';
 
-import { ErrorLog, ErrorService } from './error.service';
+import { ErrorService } from './error.service';
 import { HttpErrorResponse } from '@angular/common/http';
 
 describe('HttpErrorService', () => {
@@ -20,76 +15,44 @@ describe('HttpErrorService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should output http errors through the error Subject()', (done) => {
+  it('should output http errors through the error Subject()', fakeAsync(() => {
     const testError: HttpErrorResponse = new HttpErrorResponse({
-      status: 400,
-      statusText: 'Bad Request'
+      error: {
+        status: 400,
+        message_code: 'test error',
+        error_message: 'test error message'
+      }
     });
-    const testErrorLog: ErrorLog = {
-      code: testError.status,
-      message: testError.message
-    };
-    service.getError().subscribe((err) => {
-      done();
-      expect(err).toEqual(testErrorLog);
-    });
-    service.handleError(testError);
-  });
 
-  it('should output application errors through the error Subject()', (done) => {
-    const testError: Error = new Error('test');
-    const testErrorLog: ErrorLog = {
-      code: testError.name,
-      message: testError.message
-    };
-    service.getError().subscribe((err) => {
-      done();
-      expect(err).toEqual(testErrorLog);
-    });
     service.handleError(testError);
-  });
-
-  it('should output unknown errors through the error Subject()', (done) => {
-    const testError = 'error';
-    service.getError().subscribe((err) => {
-      done();
-      expect(err.data).toEqual(testError);
+    service.getError().subscribe((error) => {
+      expect(error).toEqual({
+        code: 'test error',
+        message: 'test error message',
+        data: error.data
+      });
     });
-    service.handleError(testError);
-  });
-
-  it('should return http errors as an observable when getError() is called', fakeAsync(() => {
-    const testError: HttpErrorResponse = new HttpErrorResponse({
-      status: 400,
-      statusText: 'Bad Request'
-    });
-    const testErrorLog: ErrorLog = {
-      code: testError.status,
-      message: testError.message
-    };
-    let error: any = {};
-    service.getError().subscribe((err) => {
-      error = err;
-    });
-    service.handleError(testError);
-    tick(5000);
-    discardPeriodicTasks();
-    expect(error).toEqual(testErrorLog);
   }));
 
-  it('should return application errors as an observable when getError() is called', fakeAsync(() => {
-    const testError: Error = new Error('test');
-    const testErrorLog: ErrorLog = {
-      code: testError.name,
-      message: testError.message
-    };
-    let error: any = {};
-    service.getError().subscribe((err) => {
-      error = err;
-    });
+  it('should output application errors through the error Subject()', fakeAsync(() => {
+    const testError = new Error('test');
     service.handleError(testError);
-    tick(5000);
-    discardPeriodicTasks();
-    expect(error).toEqual(testErrorLog);
+    service.getError().subscribe((error) => {
+      expect(error).toEqual({
+        code: 'Error',
+        message: 'test'
+      });
+    });
+  }));
+
+  it('should pass through unknown errors', fakeAsync(() => {
+    const testError = 'test';
+    service.handleError(testError);
+    service.getError().subscribe((error) => {
+      expect(error).toEqual({
+        code: 'Error',
+        message: 'Unknown error'
+      });
+    });
   }));
 });

--- a/src/shared/services/error/error.service.ts
+++ b/src/shared/services/error/error.service.ts
@@ -1,5 +1,5 @@
 import { ErrorHandler, Injectable } from '@angular/core';
-import { Observable, Subject } from 'rxjs';
+import { Observable, ReplaySubject } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
 
 export interface ErrorLog {
@@ -12,14 +12,15 @@ export interface ErrorLog {
   providedIn: 'root'
 })
 export class ErrorService implements ErrorHandler {
-  error: Subject<ErrorLog> = new Subject();
+  error: ReplaySubject<ErrorLog> = new ReplaySubject(1);
   constructor() {}
 
   handleError(err: any) {
     if (err instanceof HttpErrorResponse) {
       this.error.next({
-        code: err.status,
-        message: err.message
+        code: err.error.message_code,
+        message: err.error.error_message,
+        data: err.error
       });
     } else if (err instanceof Error) {
       this.error.next({
@@ -29,8 +30,7 @@ export class ErrorService implements ErrorHandler {
     } else {
       this.error.next({
         code: 'Error',
-        message: 'Unknown error',
-        data: err
+        message: 'Unknown error'
       });
     }
   }

--- a/src/shared/services/quote/quote.service.spec.ts
+++ b/src/shared/services/quote/quote.service.spec.ts
@@ -78,7 +78,7 @@ describe('QuoteService', () => {
       testAmounts,
       PostQuoteBankModel.SideEnum.Buy,
       'asset'
-    ).map((quote) => quote.receive_amount) as string[];
+    ).map((quote) => quote.receive_amount) as unknown as string[];
     expect(testedAmounts).toEqual(expectedAmounts);
 
     /* Side = 'buy', Input = 'counter_asset' */
@@ -93,7 +93,7 @@ describe('QuoteService', () => {
       testAmounts,
       PostQuoteBankModel.SideEnum.Buy,
       'counter_asset'
-    ).map((quote) => quote.deliver_amount) as string[];
+    ).map((quote) => quote.deliver_amount) as unknown as string[];
     expect(testedAmounts).toEqual(expectedAmounts);
 
     /* Side = 'sell', Input = 'asset' */
@@ -108,7 +108,7 @@ describe('QuoteService', () => {
       testAmounts,
       PostQuoteBankModel.SideEnum.Sell,
       'asset'
-    ).map((quote) => quote.deliver_amount) as string[];
+    ).map((quote) => quote.deliver_amount) as unknown as string[];
     expect(testedAmounts).toEqual(expectedAmounts);
 
     /* Side = 'sell', Input = 'counter_asset' */
@@ -123,7 +123,7 @@ describe('QuoteService', () => {
       testAmounts,
       PostQuoteBankModel.SideEnum.Sell,
       'counter_asset'
-    ).map((quote) => quote.receive_amount) as string[];
+    ).map((quote) => quote.receive_amount) as unknown as string[];
     expect(testedAmounts).toEqual(expectedAmounts);
 
     /* Testing with ETH asset and USD counter_asset
@@ -145,7 +145,7 @@ describe('QuoteService', () => {
       testAmounts,
       PostQuoteBankModel.SideEnum.Buy,
       'asset'
-    ).map((quote) => quote.receive_amount) as string[];
+    ).map((quote) => quote.receive_amount) as unknown as string[];
     expect(testedAmounts).toEqual(expectedAmounts);
 
     /* Side = 'sell', Input = 'asset' */
@@ -161,7 +161,7 @@ describe('QuoteService', () => {
       testAmounts,
       PostQuoteBankModel.SideEnum.Sell,
       'asset'
-    ).map((quote) => quote.deliver_amount) as string[];
+    ).map((quote) => quote.deliver_amount) as unknown as string[];
     expect(testedAmounts).toEqual(expectedAmounts);
   });
 });

--- a/src/shared/services/quote/quote.service.spec.ts
+++ b/src/shared/services/quote/quote.service.spec.ts
@@ -78,7 +78,7 @@ describe('QuoteService', () => {
       testAmounts,
       PostQuoteBankModel.SideEnum.Buy,
       'asset'
-    ).map((quote) => quote.receive_amount);
+    ).map((quote) => quote.receive_amount) as string[];
     expect(testedAmounts).toEqual(expectedAmounts);
 
     /* Side = 'buy', Input = 'counter_asset' */
@@ -93,7 +93,7 @@ describe('QuoteService', () => {
       testAmounts,
       PostQuoteBankModel.SideEnum.Buy,
       'counter_asset'
-    ).map((quote) => quote.deliver_amount);
+    ).map((quote) => quote.deliver_amount) as string[];
     expect(testedAmounts).toEqual(expectedAmounts);
 
     /* Side = 'sell', Input = 'asset' */
@@ -108,7 +108,7 @@ describe('QuoteService', () => {
       testAmounts,
       PostQuoteBankModel.SideEnum.Sell,
       'asset'
-    ).map((quote) => quote.deliver_amount);
+    ).map((quote) => quote.deliver_amount) as string[];
     expect(testedAmounts).toEqual(expectedAmounts);
 
     /* Side = 'sell', Input = 'counter_asset' */
@@ -123,7 +123,7 @@ describe('QuoteService', () => {
       testAmounts,
       PostQuoteBankModel.SideEnum.Sell,
       'counter_asset'
-    ).map((quote) => quote.receive_amount);
+    ).map((quote) => quote.receive_amount) as string[];
     expect(testedAmounts).toEqual(expectedAmounts);
 
     /* Testing with ETH asset and USD counter_asset
@@ -145,7 +145,7 @@ describe('QuoteService', () => {
       testAmounts,
       PostQuoteBankModel.SideEnum.Buy,
       'asset'
-    ).map((quote) => quote.receive_amount);
+    ).map((quote) => quote.receive_amount) as string[];
     expect(testedAmounts).toEqual(expectedAmounts);
 
     /* Side = 'sell', Input = 'asset' */
@@ -161,7 +161,7 @@ describe('QuoteService', () => {
       testAmounts,
       PostQuoteBankModel.SideEnum.Sell,
       'asset'
-    ).map((quote) => quote.deliver_amount);
+    ).map((quote) => quote.deliver_amount) as string[];
     expect(testedAmounts).toEqual(expectedAmounts);
   });
 });

--- a/src/shared/services/quote/quote.service.spec.ts
+++ b/src/shared/services/quote/quote.service.spec.ts
@@ -78,7 +78,7 @@ describe('QuoteService', () => {
       testAmounts,
       PostQuoteBankModel.SideEnum.Buy,
       'asset'
-    ).map((quote) => quote.receive_amount) as unknown as string[];
+    ).map((quote) => quote.receive_amount) as string[];
     expect(testedAmounts).toEqual(expectedAmounts);
 
     /* Side = 'buy', Input = 'counter_asset' */
@@ -93,7 +93,7 @@ describe('QuoteService', () => {
       testAmounts,
       PostQuoteBankModel.SideEnum.Buy,
       'counter_asset'
-    ).map((quote) => quote.deliver_amount) as unknown as string[];
+    ).map((quote) => quote.deliver_amount) as string[];
     expect(testedAmounts).toEqual(expectedAmounts);
 
     /* Side = 'sell', Input = 'asset' */
@@ -108,7 +108,7 @@ describe('QuoteService', () => {
       testAmounts,
       PostQuoteBankModel.SideEnum.Sell,
       'asset'
-    ).map((quote) => quote.deliver_amount) as unknown as string[];
+    ).map((quote) => quote.deliver_amount) as string[];
     expect(testedAmounts).toEqual(expectedAmounts);
 
     /* Side = 'sell', Input = 'counter_asset' */
@@ -123,7 +123,7 @@ describe('QuoteService', () => {
       testAmounts,
       PostQuoteBankModel.SideEnum.Sell,
       'counter_asset'
-    ).map((quote) => quote.receive_amount) as unknown as string[];
+    ).map((quote) => quote.receive_amount) as string[];
     expect(testedAmounts).toEqual(expectedAmounts);
 
     /* Testing with ETH asset and USD counter_asset
@@ -145,7 +145,7 @@ describe('QuoteService', () => {
       testAmounts,
       PostQuoteBankModel.SideEnum.Buy,
       'asset'
-    ).map((quote) => quote.receive_amount) as unknown as string[];
+    ).map((quote) => quote.receive_amount) as string[];
     expect(testedAmounts).toEqual(expectedAmounts);
 
     /* Side = 'sell', Input = 'asset' */
@@ -161,7 +161,7 @@ describe('QuoteService', () => {
       testAmounts,
       PostQuoteBankModel.SideEnum.Sell,
       'asset'
-    ).map((quote) => quote.deliver_amount) as unknown as string[];
+    ).map((quote) => quote.deliver_amount) as string[];
     expect(testedAmounts).toEqual(expectedAmounts);
   });
 });

--- a/src/shared/services/quote/quote.service.spec.ts
+++ b/src/shared/services/quote/quote.service.spec.ts
@@ -50,10 +50,10 @@ describe('QuoteService', () => {
 
   it('should build and return a postQuoteBankModel', () => {
     /* Testing with BTC asset and USD counter_asset */
-    let testAmounts = [0.01, 12, 123456, 12345678910];
+    let testAmounts = ['0.01', '12', '123456', '12345678910'];
 
     function testQuote(
-      amounts: number[],
+      amounts: string[],
       side: PostQuoteBankModel.SideEnum,
       input: string
     ): PostQuoteBankModel[] {
@@ -69,49 +69,61 @@ describe('QuoteService', () => {
     /* Side = 'buy', Input = 'asset' */
     let expectedAmounts = [
       // Satoshi
-      1000000, 1200000000, 12345600000000, 1234567891000000000
+      '1000000',
+      '1200000000',
+      '12345600000000',
+      '1234567891000000000'
     ];
-    let testedAmounts: number[] = testQuote(
+    let testedAmounts = testQuote(
       testAmounts,
       PostQuoteBankModel.SideEnum.Buy,
       'asset'
-    ).map((quote) => quote.receive_amount) as number[];
+    ).map((quote) => quote.receive_amount);
     expect(testedAmounts).toEqual(expectedAmounts);
 
     /* Side = 'buy', Input = 'counter_asset' */
     expectedAmounts = [
       // Cents
-      1, 1200, 12345600, 1234567891000
+      '1',
+      '1200',
+      '12345600',
+      '1234567891000'
     ];
     testedAmounts = testQuote(
       testAmounts,
       PostQuoteBankModel.SideEnum.Buy,
       'counter_asset'
-    ).map((quote) => quote.deliver_amount) as number[];
+    ).map((quote) => quote.deliver_amount);
     expect(testedAmounts).toEqual(expectedAmounts);
 
     /* Side = 'sell', Input = 'asset' */
     expectedAmounts = [
       // Satoshi
-      1000000, 1200000000, 12345600000000, 1234567891000000000
+      '1000000',
+      '1200000000',
+      '12345600000000',
+      '1234567891000000000'
     ];
     testedAmounts = testQuote(
       testAmounts,
       PostQuoteBankModel.SideEnum.Sell,
       'asset'
-    ).map((quote) => quote.deliver_amount) as number[];
+    ).map((quote) => quote.deliver_amount);
     expect(testedAmounts).toEqual(expectedAmounts);
 
     /* Side = 'sell', Input = 'counter_asset' */
     expectedAmounts = [
       // Cents
-      1, 1200, 12345600, 1234567891000
+      '1',
+      '1200',
+      '12345600',
+      '1234567891000'
     ];
     testedAmounts = testQuote(
       testAmounts,
       PostQuoteBankModel.SideEnum.Sell,
       'counter_asset'
-    ).map((quote) => quote.receive_amount) as number[];
+    ).map((quote) => quote.receive_amount);
     expect(testedAmounts).toEqual(expectedAmounts);
 
     /* Testing with ETH asset and USD counter_asset
@@ -121,31 +133,35 @@ describe('QuoteService', () => {
      */
 
     /* Side = 'buy', Input = 'asset' */
-    testAmounts = [0.01, 12, 1234];
+    testAmounts = ['0.01', '12', '1234'];
     asset = TestConstants.ETH_ASSET;
     expectedAmounts = [
       // Wei
-      10000000000000000, 12000000000000000000, 1234000000000000000000
+      '10000000000000000',
+      '12000000000000000000',
+      '1234000000000000000000'
     ];
     testedAmounts = testQuote(
       testAmounts,
       PostQuoteBankModel.SideEnum.Buy,
       'asset'
-    ).map((quote) => quote.receive_amount) as number[];
+    ).map((quote) => quote.receive_amount);
     expect(testedAmounts).toEqual(expectedAmounts);
 
     /* Side = 'sell', Input = 'asset' */
-    testAmounts = [0.01, 12, 1234];
+    testAmounts = ['0.01', '12', '1234'];
     asset = TestConstants.ETH_ASSET;
     expectedAmounts = [
       // Wei
-      10000000000000000, 12000000000000000000, 1234000000000000000000
+      '10000000000000000',
+      '12000000000000000000',
+      '1234000000000000000000'
     ];
     testedAmounts = testQuote(
       testAmounts,
       PostQuoteBankModel.SideEnum.Sell,
       'asset'
-    ).map((quote) => quote.deliver_amount) as number[];
+    ).map((quote) => quote.deliver_amount);
     expect(testedAmounts).toEqual(expectedAmounts);
   });
 });

--- a/src/shared/services/quote/quote.service.ts
+++ b/src/shared/services/quote/quote.service.ts
@@ -56,13 +56,13 @@ export class QuoteService {
             amount,
             asset,
             'base'
-          );
+          ) as string;
         } else {
           postQuoteBankModel.deliver_amount = this.assetPipe.transform(
             amount,
             counterAsset,
             'base'
-          );
+          ) as string;
         }
         break;
       }
@@ -72,13 +72,13 @@ export class QuoteService {
             amount,
             counterAsset,
             'base'
-          );
+          ) as string;
         } else {
           postQuoteBankModel.deliver_amount = this.assetPipe.transform(
             amount,
             asset,
             'base'
-          );
+          ) as string;
         }
       }
     }

--- a/src/shared/services/quote/quote.service.ts
+++ b/src/shared/services/quote/quote.service.ts
@@ -36,7 +36,7 @@ export class QuoteService {
   }
 
   getQuote(
-    amount: number,
+    amount: string | number,
     input: string,
     side: PostQuoteBankModel.SideEnum,
     asset: AssetBankModel,
@@ -56,13 +56,13 @@ export class QuoteService {
             amount,
             asset,
             'base'
-          ) as number;
+          );
         } else {
           postQuoteBankModel.deliver_amount = this.assetPipe.transform(
             amount,
             counterAsset,
             'base'
-          ) as number;
+          );
         }
         break;
       }
@@ -72,13 +72,13 @@ export class QuoteService {
             amount,
             counterAsset,
             'base'
-          ) as number;
+          );
         } else {
           postQuoteBankModel.deliver_amount = this.assetPipe.transform(
             amount,
             asset,
             'base'
-          ) as number;
+          );
         }
       }
     }


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [X] Bug fix

### Linked issue
https://cybrid.atlassian.net/browse/CYB-479

### Why
The bank client `number` types are now `string`.

### How
Refactored affected code to use `string`, or convert `string` to `number` where necessary.