### PR TITLE
feat: add navigation component and css changes

### DIFF
--- a/cypress/e2e/account-list.cy.ts
+++ b/cypress/e2e/account-list.cy.ts
@@ -6,15 +6,6 @@ function app() {
 }
 
 function accountListSetup() {
-  // Mock prices
-  cy.intercept('GET', '/api/prices', (req) => {
-    req.reply(TestConstants.SYMBOL_PRICE_BANK_MODEL_ARRAY);
-  }).as('listPrices');
-  // Mock accounts
-  cy.intercept('GET', 'api/accounts', (req) => {
-    req.reply(TestConstants.ACCOUNT_LIST_BANK_MODEL);
-  }).as('listAccounts');
-
   cy.intercept('POST', '/oauth/token', (req) => {
     req.body.client_id = Cypress.env('CLIENT_ID');
     req.body.client_secret = Cypress.env('CLIENT_SECRET');
@@ -37,6 +28,17 @@ describe('account-list test', () => {
   });
 
   it('should display account data', () => {
+    // Mock prices
+    cy.intercept('GET', '/api/prices', (req) => {
+      req.reply(TestConstants.SYMBOL_PRICE_BANK_MODEL_ARRAY);
+    }).as('listPrices');
+    // Mock accounts
+    cy.intercept('GET', 'api/accounts', (req) => {
+      req.reply(TestConstants.ACCOUNT_LIST_BANK_MODEL);
+    }).as('listAccounts');
+
+    cy.wait(['@listPrices', '@listAccounts']);
+
     // Check for mocked data and labels
     app()
       .find('.cybrid-balance')

--- a/cypress/e2e/account-list.cy.ts
+++ b/cypress/e2e/account-list.cy.ts
@@ -65,7 +65,7 @@ describe('account-list test', () => {
   });
 
   it('should navigate back', () => {
-    app().find('#back').click();
+    app().find('app-navigation').find('button').click();
     app().should('not.exist');
 
     // Reset to account-list component

--- a/cypress/e2e/trade.cy.ts
+++ b/cypress/e2e/trade.cy.ts
@@ -23,7 +23,7 @@ describe('trade test', () => {
   });
 
   it('should navigate back to the price list', () => {
-    app().find('.cybrid-navigation').click();
+    app().find('app-navigation').find('button').click();
     app().should('not.exist');
     cy.get('app-price-list').should('exist');
 

--- a/library/src/app/components/account-list/account-list.component.html
+++ b/library/src/app/components/account-list/account-list.component.html
@@ -1,17 +1,7 @@
 <ng-container *ngIf="(isRecoverable$ | async) !== false; else error">
   <ng-container *ngIf="(isLoading$ | async) !== true; else loading">
     <ng-container *ngIf="configService.getConfig$() | async as config">
-      <div class="cybrid-header">
-        <button
-          *ngIf="config.routing"
-          id="back"
-          mat-icon-button
-          color="primary"
-          (click)="onNavigate()"
-        >
-          <mat-icon>arrow_back</mat-icon>
-        </button>
-      </div>
+      <app-navigation [routingData]="routingData"></app-navigation>
       <ng-container *ngIf="balance$ | async as balance">
         <div class="cybrid-balance">
           <span class="mat-hint">{{ 'accountList.total' | translate }}</span>

--- a/library/src/app/components/account-list/account-list.component.spec.ts
+++ b/library/src/app/components/account-list/account-list.component.spec.ts
@@ -160,16 +160,6 @@ describe('AccountListComponent', () => {
     discardPeriodicTasks();
   }));
 
-  it('should call the routing service onNavigate', () => {
-    component.ngOnInit();
-    component.onNavigate();
-
-    expect(MockRoutingService.handleRoute).toHaveBeenCalledWith(
-      'trade',
-      'account-list'
-    );
-  });
-
   it('should sort custom data fields', () => {
     // Get first account ('ETH-USD')
     let account: Account = TestConstants.ACCOUNT_OVERVIEW.accounts[0];

--- a/library/src/app/components/account-list/account-list.component.ts
+++ b/library/src/app/components/account-list/account-list.component.ts
@@ -24,9 +24,9 @@ import {
   ConfigService,
   EventService,
   ErrorService,
-  RoutingService,
   AssetService,
-  Asset
+  Asset,
+  RoutingData
 } from '@services';
 
 // Utility
@@ -53,6 +53,10 @@ export class AccountListComponent implements OnInit, OnDestroy {
   isLoading$ = new BehaviorSubject(true);
   isRecoverable$ = new BehaviorSubject(true);
   private unsubscribe$ = new Subject();
+  routingData: RoutingData = {
+    route: 'price-list',
+    origin: 'account-list'
+  };
 
   dataSource = new MatTableDataSource<Account>();
   displayedColumns: string[] = ['asset', 'balance'];
@@ -63,8 +67,7 @@ export class AccountListComponent implements OnInit, OnDestroy {
     private assetService: AssetService,
     private eventService: EventService,
     private errorService: ErrorService,
-    private accountService: AccountService,
-    private routingService: RoutingService
+    private accountService: AccountService
   ) {}
 
   ngOnInit(): void {
@@ -161,9 +164,5 @@ export class AccountListComponent implements OnInit, OnDestroy {
       default:
         return '';
     }
-  }
-
-  onNavigate(): void {
-    this.routingService.handleRoute('trade', 'account-list');
   }
 }

--- a/library/src/app/components/app/app.component.ts
+++ b/library/src/app/components/app/app.component.ts
@@ -159,7 +159,10 @@ export class AppComponent implements OnInit {
           this.router.navigate(['app/' + component]);
 
           // Handles host navigation request for events
-          this.routingService.handleRoute(component, 'cybrid-app');
+          this.routingService.handleRoute({
+            route: component,
+            origin: 'cybrid-app'
+          });
         })
       )
       .subscribe();

--- a/library/src/app/components/index.ts
+++ b/library/src/app/components/index.ts
@@ -8,3 +8,4 @@ export { TradeComponent } from './trade/trade.component';
 export { TradeConfirmComponent } from './trade-confirm/trade-confirm.component';
 export { TradeSummaryComponent } from './trade-summary/trade-summary.component';
 export { AccountListComponent } from './account-list/account-list.component';
+export { NavigationComponent } from './navigation/navigation.component';

--- a/library/src/app/components/navigation/navigation.component.html
+++ b/library/src/app/components/navigation/navigation.component.html
@@ -1,0 +1,7 @@
+<ng-container *ngIf="(configService.getConfig$() | async)?.routing === true">
+  <div class="cybrid-header">
+    <button mat-icon-button color="primary" (click)="onNavigate()">
+      <mat-icon>arrow_back</mat-icon>
+    </button>
+  </div>
+</ng-container>

--- a/library/src/app/components/navigation/navigation.component.spec.ts
+++ b/library/src/app/components/navigation/navigation.component.spec.ts
@@ -7,15 +7,12 @@ import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { RoutingData, RoutingService } from '@services';
 
 describe('NavigationComponent', () => {
   let component: NavigationComponent;
   let fixture: ComponentFixture<NavigationComponent>;
 
-  let MockConfigService = jasmine.createSpyObj('ConfigService', [
-    'setConfig',
-    'getConfig$'
-  ]);
   let MockRoutingService = jasmine.createSpyObj('RoutingService', [
     'handleRoute'
   ]);
@@ -34,8 +31,11 @@ describe('NavigationComponent', () => {
           }
         })
       ],
+      providers: [{ provide: RoutingService, useValue: MockRoutingService }],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
+
+    MockRoutingService = TestBed.inject(RoutingService);
 
     fixture = TestBed.createComponent(NavigationComponent);
     component = fixture.componentInstance;
@@ -44,5 +44,18 @@ describe('NavigationComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should navigate', () => {
+    const testRoutingData: RoutingData = {
+      route: 'test',
+      origin: 'karma'
+    };
+    component.routingData = testRoutingData;
+
+    component.onNavigate();
+    expect(MockRoutingService.handleRoute).toHaveBeenCalledWith(
+      testRoutingData
+    );
   });
 });

--- a/library/src/app/components/navigation/navigation.component.spec.ts
+++ b/library/src/app/components/navigation/navigation.component.spec.ts
@@ -1,0 +1,48 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NavigationComponent } from '@components';
+import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { HttpLoaderFactory } from '../../modules/library.module';
+import { HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+
+describe('NavigationComponent', () => {
+  let component: NavigationComponent;
+  let fixture: ComponentFixture<NavigationComponent>;
+
+  let MockConfigService = jasmine.createSpyObj('ConfigService', [
+    'setConfig',
+    'getConfig$'
+  ]);
+  let MockRoutingService = jasmine.createSpyObj('RoutingService', [
+    'handleRoute'
+  ]);
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [NavigationComponent],
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useFactory: HttpLoaderFactory,
+            deps: [HttpClient]
+          }
+        })
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NavigationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/library/src/app/components/navigation/navigation.component.ts
+++ b/library/src/app/components/navigation/navigation.component.ts
@@ -1,0 +1,22 @@
+import { Component, Input } from '@angular/core';
+
+// Services
+import { ConfigService, RoutingData, RoutingService } from '@services';
+
+@Component({
+  selector: 'app-navigation',
+  templateUrl: './navigation.component.html',
+  styleUrls: ['./navigation.component.scss']
+})
+export class NavigationComponent {
+  @Input() routingData: RoutingData = { origin: '', route: '' };
+
+  constructor(
+    public configService: ConfigService,
+    private routingService: RoutingService
+  ) {}
+
+  onNavigate(): void {
+    this.routingService.handleRoute(this.routingData);
+  }
+}

--- a/library/src/app/components/price-list/price-list.component.ts
+++ b/library/src/app/components/price-list/price-list.component.ts
@@ -192,7 +192,11 @@ export class PriceListComponent implements OnInit, AfterViewChecked, OnDestroy {
                 symbol_pair: row.symbol
               }
             };
-            this.routingService.handleRoute('trade', 'price-list', extras);
+            this.routingService.handleRoute({
+              route: 'trade',
+              origin: 'price-list',
+              extras
+            });
           }
         })
       )

--- a/library/src/app/components/trade-summary/trade-summary.component.ts
+++ b/library/src/app/components/trade-summary/trade-summary.component.ts
@@ -86,6 +86,6 @@ export class TradeSummaryComponent implements OnInit {
   }
 
   onDialogClose(): void {
-    this.routingService.handleRoute('price-list', 'trade');
+    this.routingService.handleRoute({ route: 'price-list', origin: 'trade' });
   }
 }

--- a/library/src/app/components/trade/trade.component.html
+++ b/library/src/app/components/trade/trade.component.html
@@ -1,17 +1,7 @@
 <ng-container *ngIf="(isRecoverable$ | async) !== false; else error">
   <ng-container *ngIf="(isLoading$ | async) !== true">
     <ng-container *ngIf="configService.getConfig$() | async as config">
-      <button
-        *ngIf="config.routing"
-        mat-button
-        color="primary"
-        (click)="onBack()"
-      >
-        <div class="cybrid-navigation">
-          <mat-icon>arrow_back</mat-icon>
-          <div>{{ 'back' | translate }}</div>
-        </div>
-      </button>
+      <app-navigation [routingData]="routingData"></app-navigation>
       <mat-tab-group
         animationDuration="0ms"
         (selectedTabChange)="onSwitchSide($event.tab.origin)"
@@ -97,8 +87,8 @@
               <ng-container *ngIf="!amount.value">
                 <span> 1 </span>
                 <span>
-                {{ asset.code }}
-              </span>
+                  {{ asset.code }}
+                </span>
                 <span> = </span>
                 <span>
                   {{ price.buy_price! | asset: counterAsset }}

--- a/library/src/app/components/trade/trade.component.scss
+++ b/library/src/app/components/trade/trade.component.scss
@@ -63,15 +63,10 @@
 }
 
 @media screen and (min-width: 1535px) {
-  .approx-wrapper {
-    margin-left: 0;
+  .cybrid-approx-wrapper {
+    margin-left: calc(50% + 0.5rem);
     display: flex;
     margin-bottom: 1rem;
-    gap: 1rem;
-    div {
-      flex-basis: 50%;
-      margin-left: 0.7rem;
-    }
   }
 
   .cybrid-input-wrapper {

--- a/library/src/app/components/trade/trade.component.spec.ts
+++ b/library/src/app/components/trade/trade.component.spec.ts
@@ -34,8 +34,7 @@ import {
   EventService,
   ErrorService,
   ConfigService,
-  QuoteService,
-  RoutingService
+  QuoteService
 } from '@services';
 
 // Utility
@@ -70,9 +69,6 @@ describe('TradeComponent', () => {
     new Error('Error');
   });
   let MockQuoteService = jasmine.createSpyObj('QuoteService', ['getQuote']);
-  let MockRoutingService = jasmine.createSpyObj('RoutingService', [
-    'handleRoute'
-  ]);
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -107,7 +103,6 @@ describe('TradeComponent', () => {
             queryParams: MockQueryParams
           }
         },
-        { provide: RoutingService, useValue: MockRoutingService },
         AssetPipe
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
@@ -131,7 +126,6 @@ describe('TradeComponent', () => {
     });
     MockQuoteService = TestBed.inject(QuoteService);
     MockQuoteService.getQuote.and.returnValue(TestConstants.POST_QUOTE);
-    MockRoutingService = TestBed.inject(RoutingService);
   });
 
   beforeEach(() => {
@@ -164,7 +158,7 @@ describe('TradeComponent', () => {
   it('should get router parameters', () => {
     MockAssetService.getAsset.and.returnValue(TestConstants.BTC_ASSET);
     component.getAssets();
-    expect(component.counterAsset.code).toEqual('BTC');
+    expect(component.asset.code).toEqual('BTC');
     MockAssetService.getAsset.and.returnValue(TestConstants.USD_ASSET);
     component.getAssets();
     expect(component.counterAsset.code).toEqual('USD');
@@ -262,15 +256,6 @@ describe('TradeComponent', () => {
     component.onSwitchSide(-1);
     expect(component.side).toEqual('buy');
     expect(getPriceSpy).toHaveBeenCalled();
-  });
-
-  it('should navigate', () => {
-    component.ngOnInit();
-    component.onBack();
-    expect(MockRoutingService.handleRoute).toHaveBeenCalledWith(
-      'price-list',
-      'trade'
-    );
   });
 
   it('should call the quote service and build quote onTrade()', () => {

--- a/library/src/app/components/trade/trade.component.ts
+++ b/library/src/app/components/trade/trade.component.ts
@@ -117,7 +117,6 @@ export class TradeComponent implements OnInit, OnDestroy {
     this.initQuoteGroup();
     this.getPrice();
     this.refreshData();
-    console.log(this.assetPipe.transform(1, this.counterAsset, 'base'));
   }
 
   ngOnDestroy() {
@@ -125,34 +124,33 @@ export class TradeComponent implements OnInit, OnDestroy {
     this.unsubscribe$.complete();
   }
 
-  /*
-  Set the current asset and counter-asset from routing data.
-  Set the list of available crypto and fiat assets.
-  * */
   getAssets(): void {
+    // Set counter-asset from component config; asset remains default (BTC)
     this.configService
       .getConfig$()
       .pipe(
         map((config) => {
-          this.route.queryParams.pipe(
-            take(1),
-            map((params) => {
-              this.asset = this.assetService.getAsset(
-                symbolSplit(params['symbol_pair'])[0]
-              );
-              if (params !== {}) {
-                this.counterAsset = this.assetService.getAsset(
-                  symbolSplit(params['symbol_pair'])[1]
-                );
-              } else {
-                this.counterAsset = this.assetService.getAsset(config.fiat);
-              }
-            })
+          this.counterAsset = this.assetService.getAsset(config.fiat);
+        })
+      )
+      .subscribe();
+
+    // Set currently selected assets based on routing data, for instance from a price list row click
+    this.route.queryParams
+      .pipe(
+        take(1),
+        map((params) => {
+          this.asset = this.assetService.getAsset(
+            symbolSplit(params['symbol_pair'])[0]
+          );
+          this.counterAsset = this.assetService.getAsset(
+            symbolSplit(params['symbol_pair'])[1]
           );
         })
       )
       .subscribe();
 
+    // Set list of available trading assets
     this.assetService
       .getAssets$()
       .pipe(

--- a/library/src/app/modules/library.module.ts
+++ b/library/src/app/modules/library.module.ts
@@ -15,6 +15,7 @@ import {
   HttpClient
 } from '@angular/common/http';
 import { createCustomElement } from '@angular/elements';
+import { MAT_DIALOG_DEFAULT_OPTIONS } from '@angular/material/dialog';
 
 // Modules
 import { MaterialModule } from '@modules';
@@ -49,7 +50,8 @@ import {
   TradeComponent,
   TradeConfirmComponent,
   TradeSummaryComponent,
-  AccountListComponent
+  AccountListComponent,
+  NavigationComponent
 } from '@components';
 
 // Utility
@@ -72,6 +74,7 @@ export function HttpLoaderFactory(http: HttpClient) {
     TradeSummaryComponent,
     AccountListComponent,
     LoadingComponent,
+    NavigationComponent,
     AssetPipe,
     TruncatePipe
   ],
@@ -119,7 +122,12 @@ export function HttpLoaderFactory(http: HttpClient) {
     { provide: HTTP_INTERCEPTORS, useClass: RetryInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor, multi: true },
     { provide: ErrorHandler, useClass: ErrorService },
-    [{ provide: MatPaginatorIntl, useClass: CustomPaginatorIntl }]
+    { provide: MatPaginatorIntl, useClass: CustomPaginatorIntl },
+    { provide: ErrorHandler, useClass: ErrorService },
+    {
+      provide: MAT_DIALOG_DEFAULT_OPTIONS,
+      useValue: { hasBackdrop: true, disableClose: true, minWidth: '320px' }
+    }
   ],
   schemas: [CUSTOM_ELEMENTS_SCHEMA]
 })

--- a/library/src/shared/constants/constants.ts
+++ b/library/src/shared/constants/constants.ts
@@ -22,6 +22,7 @@ export class Constants {
   static ROUTING = true;
   static ICON_HOST = 'https://images.cybrid.xyz/sdk/assets/svg/color/';
   static BTC_ICON = 'https://images.cybrid.xyz/sdk/assets/svg/color/btc.svg';
+  static USD_ICON = 'https://images.cybrid.xyz/sdk/assets/svg/color/usd.svg';
   static BTC_ASSET: Asset = {
     code: 'BTC',
     decimals: '8',
@@ -36,7 +37,7 @@ export class Constants {
     name: 'Dollar',
     symbol: '$',
     type: 'fiat',
-    url: Constants.BTC_ICON
+    url: Constants.USD_ICON
   };
   static DEFAULT_CONFIG: ComponentConfig = {
     refreshInterval: Constants.REFRESH_INTERVAL,

--- a/library/src/shared/services/index.ts
+++ b/library/src/shared/services/index.ts
@@ -5,4 +5,4 @@ export { ErrorService, ErrorLog } from './error/error.service';
 export { EventService, LEVEL, CODE, EventLog } from './event/event.service';
 export { QuoteService } from './quote/quote.service';
 export { AccountService, Account } from './account/account.service';
-export { RoutingService } from './routing/routing.service';
+export { RoutingService, RoutingData } from './routing/routing.service';

--- a/library/src/shared/services/routing/routing.service.spec.ts
+++ b/library/src/shared/services/routing/routing.service.spec.ts
@@ -57,7 +57,7 @@ describe('RoutingService', () => {
     // Set config.routing
     MockConfigService.getConfig$.and.returnValue(of({ routing: true }));
 
-    service.handleRoute('trade', 'price-list');
+    service.handleRoute({ route: 'trade', origin: 'price-list' });
     tick();
 
     expect(MockConfigService.getConfig$).toHaveBeenCalled();
@@ -69,7 +69,7 @@ describe('RoutingService', () => {
     // Set config.routing
     MockConfigService.getConfig$.and.returnValue(of({ routing: false }));
 
-    service.handleRoute('trade', 'price-list');
+    service.handleRoute({ route: 'trade', origin: 'price-list' });
     tick();
 
     expect(MockConfigService.getConfig$).toHaveBeenCalled();

--- a/library/src/shared/services/routing/routing.service.ts
+++ b/library/src/shared/services/routing/routing.service.ts
@@ -4,6 +4,12 @@ import { CODE, EventService, LEVEL } from '../event/event.service';
 import { ComponentConfig, ConfigService } from '../config/config.service';
 import { map } from 'rxjs';
 
+export interface RoutingData {
+  route: string;
+  origin: string;
+  extras?: NavigationExtras;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -14,32 +20,32 @@ export class RoutingService {
     private configService: ConfigService
   ) {}
 
-  handleRoute(route: string, origin: string, extras?: NavigationExtras): void {
+  handleRoute(routingData: RoutingData): void {
     this.configService
       .getConfig$()
       .pipe(
         map((config: ComponentConfig) => {
-          const path = 'app/' + route;
+          const path = 'app/' + routingData.route;
 
           if (config.routing) {
             this.eventService.handleEvent(
               LEVEL.INFO,
               CODE.ROUTING_START,
-              'Routing to: ' + route,
+              'Routing to: ' + routingData.route,
               {
-                origin: origin,
-                default: route
+                origin: routingData.origin,
+                default: routingData.route
               }
             );
 
-            this.router.navigate([path], extras).then(() => {
+            this.router.navigate([path], routingData.extras).then(() => {
               this.eventService.handleEvent(
                 LEVEL.INFO,
                 CODE.ROUTING_END,
-                'Successfully routed to: ' + route,
+                'Successfully routed to: ' + routingData,
                 {
-                  origin: origin,
-                  default: route
+                  origin: routingData.origin,
+                  default: routingData.route
                 }
               );
             });
@@ -49,8 +55,8 @@ export class RoutingService {
               CODE.ROUTING_REQUEST,
               'Routing has been requested',
               {
-                origin: origin,
-                default: route
+                origin: routingData.origin,
+                default: routingData.route
               }
             );
           }

--- a/library/src/shared/styles/theme.scss
+++ b/library/src/shared/styles/theme.scss
@@ -177,14 +177,24 @@ $light-theme: mat.define-light-theme(
   @include mat.all-component-themes($light-theme);
 }
 .cybrid-dark-theme {
-  .mat-option:not(.mat-selected) {
-    color: white;
-  }
   @include mat.all-component-colors($dark-theme);
+
+  // Default material component dark theme overrides
+
+  // Material select options menu
+  .mat-primary .mat-option.mat-selected:not(.mat-option-disabled) {
+    color: $light-primary-text !important;
+  }
+  .mat-primary .mat-option:not(.mat-option-disabled) {
+    color: $light-secondary-text !important;
+  }
 }
 
 /* Global Styles */
 .cybrid-global {
+  max-width: 905px;
+  margin: auto;
+
   .cybrid-column {
     display: flex;
     flex-direction: column;
@@ -207,18 +217,8 @@ $light-theme: mat.define-light-theme(
     margin: 0;
   }
 
-  .cybrid-navigation {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    gap: 0.5rem;
-    font-weight: 400;
-    mat-icon {
-      height: 1rem;
-      width: 1rem;
-      line-height: 1rem;
-      font-size: 1rem;
-    }
+  .cybrid-app {
+    max-width: 905px;
   }
 
   .cybrid-pointer {

--- a/library/src/shared/styles/theme.scss
+++ b/library/src/shared/styles/theme.scss
@@ -217,10 +217,6 @@ $light-theme: mat.define-light-theme(
     margin: 0;
   }
 
-  .cybrid-app {
-    max-width: 905px;
-  }
-
   .cybrid-pointer {
     cursor: pointer;
   }


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [X] Feature
- [ ] Bug fix

### Linked issue

- [X] Not tracked

### Why
We need to genericise app routing to simplify component template and testing.

### How
Added navigation component and refactored code to implement it across the app.

Also included:
- Trade component style cleanup (fixed large screen view)
- Implemented config defined fiat counter-asset in the trade component
- Fixed flaky e2e test in the account-list component
- Disabled backdrop click and escape key exits from dialogs (resulting in potentially strange ui states)