### PR TITLE
feat: add account-details e2e

### DIFF
--- a/cypress/e2e/account-details.cy.ts
+++ b/cypress/e2e/account-details.cy.ts
@@ -1,0 +1,161 @@
+import { TestConstants } from '@constants';
+
+function app() {
+  return cy.get('app-account-details');
+}
+
+function accountDetailsSetup() {
+  cy.get('#component')
+    .click()
+    .get('mat-option')
+    .contains('account-list')
+    .click();
+  cy.get('tr').contains('BTC').click();
+}
+
+describe('account-details test', () => {
+  before(() => {
+    cy.visit('/');
+    // @ts-ignore
+    cy.login();
+  });
+
+  beforeEach(() => {
+    // Mock prices
+    cy.intercept('GET', 'api/prices*', (req) => {
+      req.reply(TestConstants.SYMBOL_PRICE_BANK_MODEL_ARRAY);
+    }).as('listPrices');
+    // Mock accounts
+    cy.intercept('GET', 'api/accounts*', (req) => {
+      req.reply(TestConstants.ACCOUNT_LIST_BANK_MODEL);
+    }).as('listAccount');
+    // Mock trades
+    cy.intercept('GET', 'api/trades*', (req) => {
+      req.reply(TestConstants.TRADE_LIST_BANK_MODEL);
+    }).as('listTrades');
+  });
+
+  it('should render account details', () => {
+    accountDetailsSetup();
+    app().should('exist');
+  });
+
+  it('should display account data', () => {
+    app()
+      .find('.cybrid-header')
+      .should('contain.text', 'Bitcoin')
+      .should('contain.text', 'BTC')
+      .should('contain.text', 'USD')
+      .should('contain.text', '$21,298.00')
+      .should('contain.text', '232.18708499')
+      .should('contain.text', '4,944,888.35');
+  });
+
+  it('should display trade data', () => {
+    app()
+      .find('tr')
+      .should('contain.text', 'Buy')
+      .should('contain.text', 'BTC')
+      .should('contain.text', 'Aug 9, 2022')
+      .should('contain.text', '123')
+      .should('contain.text', '1')
+      .should('contain.text', '$2,845,277.82')
+      .should('contain.text', '$23,092.68');
+  });
+
+  it('should display trade summary', () => {
+    // Select first trade in the table
+    cy.get('.mat-row').first().click();
+
+    cy.get('.cybrid-subtitle').should(
+      'contain.text',
+      '$2,845,277.82 USD in BTC'
+    );
+    cy.get('.cybrid-subheader-item')
+      .should('contain.text', '718902509...')
+      .should('contain.text', 'Aug 9, 2022');
+    cy.get('.cybrid-list-item')
+      .should('contain.text', 'Status')
+      .should('contain.text', 'Settling')
+      .should('contain.text', 'Purchased amount')
+      .should('contain.text', '$2,845,277.82')
+      .should('contain.text', 'USD')
+      .should('contain.text', 'Purchased quantity')
+      .should('contain.text', '123 BTC')
+      .should('contain.text', 'Transaction fee')
+      .should('contain.text', '$0.00');
+    cy.get('app-trade-summary').find('button').click();
+  });
+
+  it('should navigate back', () => {
+    app().find('app-navigation').find('button').click();
+    app().should('not.exist');
+
+    // Reset to account-details component
+    accountDetailsSetup();
+  });
+
+  it('should refresh the account list and paginate', () => {
+    // Reset mocks
+    cy.intercept('GET', 'api/prices*', (req) => {
+      req.continue();
+    });
+    cy.intercept('GET', 'api/accounts*', (req) => {
+      req.continue();
+    }).as('listAccount');
+    cy.intercept('GET', 'api/trades*', (req) => {
+      req.continue();
+    }).as('listTrades');
+
+    // Intercept listAccounts response
+    let account;
+    cy.wait('@listAccount').then((interception) => {
+      // @ts-ignore
+      account = interception.response.body;
+    });
+    // Intercept listTrades response
+    let trades;
+    cy.wait('@listTrades').then((interception) => {
+      // @ts-ignore
+      trades = interception.response.body;
+    });
+
+    // Check for new data
+    cy.wait('@listAccount').its('response.body').should('not.eq', account);
+    cy.wait('@listTrades').its('response.body').should('not.eq', trades);
+
+    // Paginate: next
+    app().find('.mat-paginator-navigation-next').click();
+
+    // Check for new data
+    cy.wait('@listTrades').its('response.body').should('not.eq', trades);
+
+    // Paginate: previous
+    app().find('.mat-paginator-navigation-previous').click();
+
+    // Check for new data
+    cy.wait('@listTrades').its('response.body').should('not.eq', trades);
+
+    // Paginate: change items per page
+    app().find('.mat-paginator-page-size-select').click();
+    cy.get('mat-option').contains('10').click();
+
+    cy.wait('@listTrades').its('response.body').should('not.eq', trades);
+    app().find('tr').should('have.length', 11);
+  });
+
+  it('should handle errors returned by trades api', () => {
+    // Force prices error
+    cy.intercept('GET', 'api/trades*', { forceNetworkError: true }).as(
+      'listTrades'
+    );
+
+    cy.wait('@listTrades').then(() => {
+      app().find('#warning').should('exist');
+    });
+  });
+
+  it('should navigate to onTrade()', () => {
+    app().find('#trade').click();
+  });
+});

--- a/cypress/e2e/account-list.cy.ts
+++ b/cypress/e2e/account-list.cy.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import { TestConstants } from '@constants';
 
 function app() {
@@ -26,7 +25,7 @@ describe('account-list test', () => {
 
   it('should display account data', () => {
     // Mock prices
-    cy.intercept('GET', '/api/prices', (req) => {
+    cy.intercept('GET', 'api/prices', (req) => {
       req.reply(TestConstants.SYMBOL_PRICE_BANK_MODEL_ARRAY);
     }).as('listPrices');
     // Mock accounts
@@ -74,7 +73,7 @@ describe('account-list test', () => {
   it('should refresh the account list', () => {
     // Intercept listAccounts response
     let accounts;
-    cy.intercept('/api/accounts').as('listAccounts');
+    cy.intercept('api/accounts').as('listAccounts');
     cy.wait('@listAccounts').then((interception) => {
       // @ts-ignore
       accounts = interception.response.body;

--- a/library/src/app/components/account-details/account-details.component.html
+++ b/library/src/app/components/account-details/account-details.component.html
@@ -1,6 +1,11 @@
 <ng-container *ngIf="(isRecoverable$ | async) !== false; else error">
   <ng-container *ngIf="(isLoading$ | async) !== true; else loading">
-    <ng-container *ngIf="configService.getConfig$() | async as config">
+    <ng-container
+      *ngIf="{
+        config: configService.getConfig$() | async,
+        component: configService.getComponent$()
+      } as data"
+    >
       <app-navigation [routingData]="routingData"></app-navigation>
       <ng-container *ngIf="account$ | async as account">
         <div class="cybrid-header">
@@ -10,47 +15,51 @@
               src="{{ account.asset.url }}"
               alt="Crypto currency icon"
             />
-            <span class="cybrid-h2"
-              >{{ account.asset.name }}
-              <span class="mat-hint">{{ account.asset.code }}</span>
-            </span>
+            <div class="cybrid-asset">
+              <div class="cybrid-asset-name">
+                <span class="cybrid-h2 cybrid-strong"
+                  >{{ account.asset.name }}
+                </span>
+                <span class="cybrid-h2 mat-hint">{{ account.asset.code }}</span>
+              </div>
+              <div class="cybrid-asset-value">
+                <span>
+                  {{ account.price.buy_price! | asset: account.counter_asset }}
+                </span>
+                <span class="mat-hint">{{ account.counter_asset.code }}</span>
+              </div>
+            </div>
           </div>
-          <div>
-            <span class="cybrid-h2">
-              {{ account.price.buy_price! | asset: account.counter_asset }}
-              <span class="mat-hint">{{ account.counter_asset.code }}</span>
-            </span>
-          </div>
-        </div>
-        <div class="cybrid-subheader">
           <div class="cybrid-holdings">
-            <span>{{ 'accountDetails.holdings' | translate }}</span>
             <div>
-              <span class="mat-body-strong"
+              <span class="cybrid-h2 cybrid-strong"
                 >{{
                   account.account.platform_balance!
                     | asset: account.asset:'trade'
                 }}
               </span>
-              <span class="mat-hint">{{ ' ' + account.asset.code }}</span>
+              <span class="cybrid-h2 mat-hint">{{
+                ' ' + account.asset.code
+              }}</span>
             </div>
             <div>
+              <span>{{ account.counter_asset.symbol }}</span>
               <span>{{
-                (account.value | currency: '':'':'':config.locale) + ' '
+                (account.value | currency: '':'':'':data.config!.locale) + ' '
               }}</span>
               <span class="mat-hint">{{ account.counter_asset.code }}</span>
             </div>
           </div>
-          <div class="cybrid-actions">
-            <button mat-flat-button color="primary" (click)="onTrade()">
-              {{ 'accountDetails.sell' | translate }}
-              {{ ' ' + account.asset.code }}
-            </button>
-            <button mat-flat-button color="primary" (click)="onTrade()">
-              {{ 'accountDetails.buy' | translate }}
-              {{ ' ' + account.asset.code }}
-            </button>
-          </div>
+        </div>
+        <div class="cybrid-actions">
+          <button
+            id="trade"
+            mat-flat-button
+            color="primary"
+            (click)="onTrade()"
+          >
+            {{ 'accountDetails.trade' | translate }}
+          </button>
         </div>
         <div class="cybrid-table">
           <mat-progress-bar
@@ -103,7 +112,7 @@
                 <div class="cybrid-sort-header">
                   <span>{{ 'accountDetails.balance' | translate }}</span>
                   <span class="mat-hint cybrid-h5 cybrid-code">{{
-                    config.fiat
+                    data.config!.fiat
                   }}</span>
                 </div>
               </th>
@@ -143,7 +152,12 @@
               </td>
             </ng-container>
             <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-            <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+            <tr
+              class="cybrid-pointer"
+              mat-row
+              *matRowDef="let row; columns: displayedColumns"
+              (click)="onRowClick(row)"
+            ></tr>
             <tr class="mat-row" *matNoDataRow>
               <td id="warning" class="mat-cell cybrid-no-data" colspan="2">
                 {{

--- a/library/src/app/components/account-details/account-details.component.scss
+++ b/library/src/app/components/account-details/account-details.component.scss
@@ -4,13 +4,17 @@
   justify-content: space-between;
   align-items: center;
   margin-bottom: 1rem;
-  padding: 0 1rem;
 }
 
 .cybrid-account {
   display: flex;
   justify-content: space-between;
-  gap: 0.5rem;
+  gap: 15px;
+}
+
+.cybrid-icon {
+  height: 48px;
+  width: 48px;
 }
 
 .cybrid-subheader {
@@ -21,15 +25,28 @@
   margin-bottom: 1rem;
 }
 
+.cybrid-asset {
+  display: flex;
+  flex-direction: column;
+  div + div {
+    margin-top: -5px;
+  }
+}
+
 .cybrid-holdings {
   display: flex;
   flex-direction: column;
+  align-items: flex-end;
+  div + div {
+    margin-top: -5px;
+  }
 }
 
 .cybrid-actions {
   display: flex;
-  align-self: flex-start;
   gap: 1rem;
+  justify-content: flex-end;
+  margin-bottom: 1rem;
 }
 
 .cybrid-table {
@@ -81,6 +98,41 @@ mat-progress-bar {
   }
 }
 
-.cybrid-buy-icon {
+.cybrid-sell-icon {
   transform: rotate(90deg);
+}
+
+@media screen and (max-width: 599px) {
+  .cybrid-header {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .cybrid-account {
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .cybrid-asset-value {
+    display: none;
+  }
+
+  .cybrid-asset-name {
+    span {
+      font-size: 1rem;
+    }
+  }
+
+  .cybrid-actions {
+    display: none;
+  }
+
+  .cybrid-icon {
+    height: inherit;
+    width: 32px;
+  }
+
+  .cybrid-holdings {
+    align-items: center;
+  }
 }

--- a/library/src/app/components/account-details/account-details.component.spec.ts
+++ b/library/src/app/components/account-details/account-details.component.spec.ts
@@ -44,7 +44,8 @@ describe('AccountDetailComponent', () => {
   ]);
   let MockConfigService = jasmine.createSpyObj('ConfigService', [
     'setConfig',
-    'getConfig$'
+    'getConfig$',
+    'getComponent$'
   ]);
   let MockQueryParams = of({
     accountID: TestConstants.ACCOUNT_GUID
@@ -209,6 +210,13 @@ describe('AccountDetailComponent', () => {
     expect(getTradesSpy).toHaveBeenCalled();
     discardPeriodicTasks();
   }));
+
+  it('should display the trade summary onRowClick()', () => {
+    const dialogSpy = spyOn(component.dialog, 'open');
+
+    component.onRowClick(TestConstants.TRADE_BANK_MODEL);
+    expect(dialogSpy).toHaveBeenCalled();
+  });
 
   it('should navigate onTrade()', () => {
     component.onTrade();

--- a/library/src/app/components/account-details/account-details.component.ts
+++ b/library/src/app/components/account-details/account-details.component.ts
@@ -44,6 +44,8 @@ import {
 // Utility
 import { Constants } from '@constants';
 import { symbolBuild } from '@utility';
+import { TradeSummaryComponent } from '../trade-summary/trade-summary.component';
+import { MatDialog } from '@angular/material/dialog';
 
 @Component({
   selector: 'app-account-details',
@@ -89,7 +91,8 @@ export class AccountDetailsComponent
     private tradeService: TradesService,
     private assetService: AssetService,
     private route: ActivatedRoute,
-    private routingService: RoutingService
+    private routingService: RoutingService,
+    public dialog: MatDialog
   ) {}
 
   ngOnInit() {
@@ -202,6 +205,10 @@ export class AccountDetailsComponent
           this.errorService.handleError(
             new Error('There was an error fetching trades')
           );
+
+          this.dataSource.data = [];
+          this.getTradesError = true;
+
           return of(err);
         })
       )
@@ -265,6 +272,16 @@ export class AccountDetailsComponent
       origin: 'account-details',
       route: 'trade',
       extras: extras
+    });
+  }
+
+  onRowClick(tradeBankModel: TradeBankModel): void {
+    this.dialog.open(TradeSummaryComponent, {
+      data: {
+        model: tradeBankModel,
+        asset: this.asset,
+        counter_asset: this.assetService.getAsset(this.counterAssetCode)
+      }
     });
   }
 }

--- a/library/src/app/components/app/app.component.spec.ts
+++ b/library/src/app/components/app/app.component.spec.ts
@@ -47,7 +47,8 @@ describe('AppComponent', () => {
   ]);
   let MockConfigService = jasmine.createSpyObj('ConfigService', [
     'setConfig',
-    'getConfig$'
+    'getConfig$',
+    'setComponent'
   ]);
   let MockRoutingService = jasmine.createSpyObj('RoutingService', [
     'handleRoute'
@@ -115,6 +116,8 @@ describe('AppComponent', () => {
   it('should set the current component', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const component = fixture.componentInstance;
+
+    MockConfigService.component$ = () => {};
 
     // Test default currentComponent
     component.initNavigation();

--- a/library/src/app/components/app/app.component.ts
+++ b/library/src/app/components/app/app.component.ts
@@ -54,6 +54,7 @@ export class AppComponent implements OnInit {
   }
   @Input()
   set component(selector: string) {
+    this.configService.setComponent(selector);
     this.currentComponent$.next(selector);
   }
 

--- a/library/src/app/components/trade-summary/trade-summary.component.html
+++ b/library/src/app/components/trade-summary/trade-summary.component.html
@@ -1,147 +1,207 @@
 <ng-container *ngIf="(isRecoverable$ | async) !== false; else error">
-  <ng-container *ngIf="trade$ | async as trade; else loading">
-    <h2 mat-dialog-title>{{ 'trade.summary.header' | translate }}</h2>
-    <mat-dialog-content>
-      <p class="mat-hint">
-        {{ 'trade.summary.message' | translate }}
-      </p>
-      <ng-container *ngIf="trade.side === 'buy'">
-        <div class="cybrid-subheader-item">
-          <div class="inner">
-            <span class="mat-body-strong">Transaction ID:</span>
-            <span matTooltip="{{ trade.guid }}" matTooltipPosition="above">{{
-              trade.guid! | truncate: 9
-            }}</span>
+  <ng-container
+    *ngIf="{
+      config: configService.getConfig$() | async,
+      component: configService.getComponent$() | async
+    } as config"
+  >
+    <ng-container *ngIf="trade$ | async as trade; else loading">
+      <h2 mat-dialog-title *ngIf="config.component === 'trade'">
+        {{ 'trade.summary.submission' | translate }}
+      </h2>
+      <h2 mat-dialog-title *ngIf="config.component === 'account-details'">
+        <img
+          class="cybrid-icon"
+          src="{{ data.asset.url }}"
+          alt="Crypto currency icon"
+        />
+        <span>{{
+          trade.side === 'buy'
+            ? ('trade.summary.buy' | translate)
+            : ('trade.summary.sell' | translate)
+        }}</span>
+      </h2>
+      <mat-dialog-content>
+        <p *ngIf="config.component === 'trade'" class="mat-hint">
+          {{ 'trade.summary.message' | translate }}
+        </p>
+
+        <p
+          *ngIf="config.component === 'account-details'"
+          class="cybrid-subtitle"
+        >
+          <span class="mat-body-strong">{{
+            (trade.side === 'buy'
+              ? trade.deliver_amount!
+              : trade.receive_amount!
+            ) | asset: data.counter_asset
+          }}</span>
+          <span> {{ data.counter_asset.code + ' ' }}</span>
+          <span>{{ ('accountTrade.subheader' | translate) + ' ' }}</span>
+          <span>{{ data.asset.code }}</span>
+        </p>
+
+        <ng-container *ngIf="trade.side === 'buy'">
+          <div class="cybrid-subheader-item">
+            <div class="inner">
+              <span class="mat-body-strong">Transaction ID:</span>
+              <span matTooltip="{{ trade.guid }}" matTooltipPosition="above">{{
+                trade.guid! | truncate: 9
+              }}</span>
+            </div>
+            <div class="inner">
+              <span class="mat-body-strong">Date:</span>
+              <span>{{ trade.created_at | date }}</span>
+            </div>
           </div>
-          <div class="inner">
-            <span class="mat-body-strong">Date:</span>
-            <span>{{ trade.created_at | date }}</span>
+          <div
+            class="cybrid-list-item"
+            *ngIf="config.component === 'account-details'"
+          >
+            <span>{{ 'trade.summary.status' | translate }}</span>
+            <span>{{ trade.state | titlecase }}</span>
           </div>
-        </div>
-        <div class="cybrid-list-item">
-          <span>
-            {{
-              ('trade.summary.purchased' | translate) +
-                ' ' +
-                ('trade.amount' | translate)
-            }}
-          </span>
-          <div>
-            <span>
-              {{ (trade.deliver_amount! | asset: data.counter_asset) + ' ' }}
-            </span>
-            <span class="mat-hint">{{ data.counter_asset.code }}</span>
-          </div>
-        </div>
-        <mat-divider></mat-divider>
-        <div class="cybrid-list-item">
-          <span
-            >{{
-              ('trade.summary.purchased' | translate) +
-                ' ' +
-                ('trade.quantity' | translate)
-            }}
-          </span>
-          <div>
-            <span>{{
-              (trade.receive_amount! | asset: data.asset:'trade') + ' '
-            }}</span>
-            <span class="mat-hint">{{ data.asset.code }}</span>
-          </div>
-        </div>
-        <mat-divider></mat-divider>
-        <div class="cybrid-list-item">
-          <span>{{ 'trade.transaction' | translate }}</span>
-          <div>
-            <span>
-              {{ (trade.fee! | asset: data.counter_asset) + ' ' }}
-            </span>
-            <span class="mat-hint">{{ data.counter_asset.code }}</span>
-          </div>
-        </div>
-        <mat-divider></mat-divider>
-      </ng-container>
-      <ng-container *ngIf="trade.side === 'sell'">
-        <div class="subheader-item cybrid-list-item">
-          <div class="inner">
-            <span class="mat-body-strong">Transaction ID:</span>
-            <span
-              class="transaction-id"
-              matTooltip="{{ trade.guid }}"
-              matTooltipPosition="above"
-              >{{ trade.guid! | truncate: 9 }}</span
-            >
-          </div>
-          <div class="inner">
-            <span class="mat-body-strong">Date:</span>
-            <span>{{ trade.created_at | date }}</span>
-          </div>
-        </div>
-        <div class="cybrid-list-item">
-          <span>
-            {{
-              ('trade.summary.sold' | translate) +
-                ' ' +
-                ('trade.amount' | translate)
-            }}
-          </span>
-          <div>
-            <span>
-              {{ (trade.receive_amount! | asset: data.counter_asset) + ' ' }}
-            </span>
-            <span class="mat-hint">{{ data.counter_asset.code }}</span>
-          </div>
-        </div>
-        <mat-divider></mat-divider>
-        <div class="cybrid-list-item">
-          <span
-            >{{
-              ('trade.summary.sold' | translate) +
-                ' ' +
-                ('trade.quantity' | translate)
-            }}
-          </span>
-          <div>
-            <span>{{
-              (trade.deliver_amount! | asset: data.asset:'trade') + ' '
-            }}</span>
-            <span class="mat-hint">{{ data.asset.code }}</span>
-          </div>
-        </div>
-        <mat-divider></mat-divider>
-        <div class="cybrid-list-item">
-          <span>{{ 'trade.transaction' | translate }}</span>
-          <div>
+          <mat-divider
+            *ngIf="config.component === 'account-details'"
+          ></mat-divider>
+          <div class="cybrid-list-item">
             <span>
               {{
-                data.counter_asset.symbol +
-                  (trade.fee! | asset: data.counter_asset:'trade') +
-                  ' '
+                ('trade.summary.purchased' | translate) +
+                  ' ' +
+                  ('trade.amount' | translate)
               }}
             </span>
-            <span class="mat-hint">{{ data.counter_asset.code }}</span>
+            <div>
+              <span>
+                {{ (trade.deliver_amount! | asset: data.counter_asset) + ' ' }}
+              </span>
+              <span class="mat-hint">{{ data.counter_asset.code }}</span>
+            </div>
           </div>
-        </div>
-        <mat-divider></mat-divider>
-      </ng-container>
-    </mat-dialog-content>
-    <mat-dialog-actions align="end">
-      <button
-        id="done"
-        mat-stroked-button
-        [mat-dialog-close]
-        (click)="onDialogClose()"
-      >
-        {{ 'done' | translate }}
-      </button>
-    </mat-dialog-actions>
+          <mat-divider></mat-divider>
+          <div class="cybrid-list-item">
+            <span
+              >{{
+                ('trade.summary.purchased' | translate) +
+                  ' ' +
+                  ('trade.quantity' | translate)
+              }}
+            </span>
+            <div>
+              <span>{{
+                (trade.receive_amount! | asset: data.asset:'trade') + ' '
+              }}</span>
+              <span class="mat-hint">{{ data.asset.code }}</span>
+            </div>
+          </div>
+          <mat-divider></mat-divider>
+          <div class="cybrid-list-item">
+            <span>{{ 'trade.transaction' | translate }}</span>
+            <div>
+              <span>
+                {{ (trade.fee! | asset: data.counter_asset) + ' ' }}
+              </span>
+              <span class="mat-hint">{{ data.counter_asset.code }}</span>
+            </div>
+          </div>
+          <mat-divider></mat-divider>
+        </ng-container>
+        <ng-container *ngIf="trade.side === 'sell'">
+          <div class="cybrid-subheader-item">
+            <div class="inner">
+              <span class="mat-body-strong">Transaction ID:</span>
+              <span matTooltip="{{ trade.guid }}" matTooltipPosition="above">{{
+                trade.guid! | truncate: 9
+              }}</span>
+            </div>
+            <div class="inner">
+              <span class="mat-body-strong">Date:</span>
+              <span>{{ trade.created_at | date }}</span>
+            </div>
+          </div>
+          <div
+            class="cybrid-list-item"
+            *ngIf="config.component === 'account-details'"
+          >
+            <span>{{ 'trade.summary.status' | translate }}</span>
+            <span>{{ trade.state | titlecase }}</span>
+          </div>
+          <mat-divider
+            *ngIf="config.component === 'account-details'"
+          ></mat-divider>
+          <div class="cybrid-list-item">
+            <span>
+              {{
+                ('trade.summary.sold' | translate) +
+                  ' ' +
+                  ('trade.amount' | translate)
+              }}
+            </span>
+            <div>
+              <span>
+                {{ (trade.receive_amount! | asset: data.counter_asset) + ' ' }}
+              </span>
+              <span class="mat-hint">{{ data.counter_asset.code }}</span>
+            </div>
+          </div>
+          <mat-divider></mat-divider>
+          <div class="cybrid-list-item">
+            <span
+              >{{
+                ('trade.summary.sold' | translate) +
+                  ' ' +
+                  ('trade.quantity' | translate)
+              }}
+            </span>
+            <div>
+              <span>{{
+                (trade.deliver_amount! | asset: data.asset:'trade') + ' '
+              }}</span>
+              <span class="mat-hint">{{ data.asset.code }}</span>
+            </div>
+          </div>
+          <mat-divider></mat-divider>
+          <div class="cybrid-list-item">
+            <span>{{ 'trade.transaction' | translate }}</span>
+            <div>
+              <span>
+                {{
+                  data.counter_asset.symbol +
+                    (trade.fee! | asset: data.counter_asset:'trade') +
+                    ' '
+                }}
+              </span>
+              <span class="mat-hint">{{ data.counter_asset.code }}</span>
+            </div>
+          </div>
+          <mat-divider></mat-divider>
+        </ng-container>
+      </mat-dialog-content>
+      <mat-dialog-actions align="end">
+        <button
+          id="done"
+          mat-stroked-button
+          [mat-dialog-close]
+          (click)="onDialogClose()"
+        >
+          {{ 'done' | translate }}
+        </button>
+      </mat-dialog-actions>
+    </ng-container>
+    <ng-template #loading>
+      <app-loading>
+        <h2>
+          {{
+            config.component === 'trade'
+              ? ('trade.summary.submitting' | translate)
+              : ('trade.summary.loading' | translate)
+          }}
+        </h2>
+      </app-loading>
+    </ng-template>
   </ng-container>
 </ng-container>
-<ng-template #loading>
-  <app-loading>
-    <h2>{{ 'trade.summary.loading' | translate }}</h2>
-  </app-loading>
-</ng-template>
 <ng-template #error>
   <mat-card>
     <mat-card-content>

--- a/library/src/app/components/trade-summary/trade-summary.component.scss
+++ b/library/src/app/components/trade-summary/trade-summary.component.scss
@@ -2,6 +2,12 @@
   display: flex;
 }
 
+h2 {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .cybrid-list-item {
   height: 3rem;
   display: flex;

--- a/library/src/app/components/trade-summary/trade-summary.component.spec.ts
+++ b/library/src/app/components/trade-summary/trade-summary.component.spec.ts
@@ -50,7 +50,8 @@ describe('TradeSummaryComponent', () => {
   ]);
   let MockConfigService = jasmine.createSpyObj('ConfigService', [
     'setConfig',
-    'getConfig$'
+    'getConfig$',
+    'getComponent$'
   ]);
   let MockTradesService = jasmine.createSpyObj('TradesService', ['getTrade']);
   let MockRoutingService = jasmine.createSpyObj('RoutingService', [
@@ -115,6 +116,7 @@ describe('TradeSummaryComponent', () => {
     MockErrorService = TestBed.inject(ErrorService);
     MockConfigService = TestBed.inject(ConfigService);
     MockConfigService.getConfig$.and.returnValue(of(TestConstants.CONFIG));
+    MockConfigService.getComponent$.and.returnValue(of('Trade'));
   });
 
   beforeEach(() => {
@@ -146,7 +148,10 @@ describe('TradeSummaryComponent', () => {
     expect(MockDialogRef.close).toHaveBeenCalled();
   });
 
-  it('should route to the price-list onDialogClose()', () => {
+  it('should route to the price-list onDialogClose() if the parent is trade', () => {
+    // Set parent component to trade
+    MockConfigService.getComponent$.and.returnValue(of('trade'));
+
     component.onDialogClose();
     expect(MockRoutingService.handleRoute).toHaveBeenCalled();
   });

--- a/library/src/app/components/trade-summary/trade-summary.component.ts
+++ b/library/src/app/components/trade-summary/trade-summary.component.ts
@@ -2,7 +2,7 @@ import { Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
-import { BehaviorSubject, catchError, map, of, Subject } from 'rxjs';
+import { BehaviorSubject, catchError, map, of, Subject, take } from 'rxjs';
 
 // Client
 import { TradeBankModel, TradesService } from '@cybrid/cybrid-api-bank-angular';
@@ -20,6 +20,7 @@ import {
 
 // Utility
 import { TranslatePipe } from '@ngx-translate/core';
+import { Router } from '@angular/router';
 
 interface DialogData {
   model: TradeBankModel;
@@ -86,6 +87,19 @@ export class TradeSummaryComponent implements OnInit {
   }
 
   onDialogClose(): void {
-    this.routingService.handleRoute({ route: 'price-list', origin: 'trade' });
+    this.configService
+      .getComponent$()
+      .pipe(
+        take(1),
+        map((component) => {
+          if (component === 'trade') {
+            this.routingService.handleRoute({
+              route: 'price-list',
+              origin: 'trade'
+            });
+          }
+        })
+      )
+      .subscribe();
   }
 }

--- a/library/src/shared/i18n/en.ts
+++ b/library/src/shared/i18n/en.ts
@@ -59,7 +59,7 @@ export default {
       id: 'Transaction ID:',
       submitting: 'Submitting crypto order',
       loading: 'Loading crypto order',
-      error: 'Error fetching trade',
+      error: 'Error fetching trade'
     }
   },
 

--- a/library/src/shared/i18n/en.ts
+++ b/library/src/shared/i18n/en.ts
@@ -48,13 +48,18 @@ export default {
 
     // Summary dialog
     summary: {
-      header: 'Order Submitted',
+      submission: 'Order Submitted',
+      details: 'in',
       message: 'Your order has been placed, thank you.',
+      status: 'Status',
       purchased: 'Purchased',
       sold: 'Sold',
+      buy: 'Buy',
+      sell: 'Sell',
       id: 'Transaction ID:',
-      loading: 'Submitting Crypto Order',
-      error: 'Error fetching trade'
+      submitting: 'Submitting crypto order',
+      loading: 'Loading crypto order',
+      error: 'Error fetching trade',
     }
   },
 
@@ -75,14 +80,34 @@ export default {
   // Account details component
   accountDetails: {
     holdings: 'Holdings',
-    buy: 'Buy',
-    sell: 'Sell',
+    trade: 'Trade',
     transactions: 'Recent Transctions',
     balance: 'Balance',
     error: {
       trade: 'Error fetching trades',
       noData: 'No trades found'
     }
+  },
+
+  // Account trade component
+  accountTrade: {
+    side: {
+      buy: 'Bought',
+      sell: 'Sold'
+    },
+    subheader: 'in',
+    status: 'Status',
+    placed: 'Placed',
+    finalized: 'Finalized',
+    date: 'Date',
+    fee: 'Fee',
+    order: 'Trade ID',
+
+    message: 'Your order has been placed, thank you.',
+    purchased: 'Purchased',
+    sold: 'Sold',
+    loading: 'Submitting Crypto Order',
+    error: 'Error fetching trade'
   },
 
   // Paginator

--- a/library/src/shared/i18n/fr.ts
+++ b/library/src/shared/i18n/fr.ts
@@ -49,12 +49,17 @@ export default {
 
     // Summary dialog
     summary: {
-      header: 'Commande Soumise',
+      submission: 'Commande Soumise',
+      details: 'en',
       message: 'Votre commande a été passée, merci.',
+      status: 'Statut',
       purchased: 'Acheté',
-      sold: 'Vendu',
+      buy: 'Acheter',
       id: 'Transaction ID:',
-      loading: 'Soumettre une commande de crypto',
+      sell: 'Vendre',
+      sold: 'Vendu',
+      submitting: 'Soumettre une commande de crypto',
+      loading: 'Chargement de la commande crypto',
       error: 'Erreur lors de la récupération de léchange'
     }
   },
@@ -73,17 +78,37 @@ export default {
     }
   },
 
-  // Account detail component
+  // Account details component
   accountDetails: {
     holdings: 'Avoirs',
-    buy: 'Acheter',
-    sell: 'Vendre',
+    trade: 'Échanger',
     transactions: 'Transactions Récentes',
     balance: 'Solde',
     error: {
       account: 'Erreur lors de la récupération des transactions',
       noData: 'Aucun commerce trouvé'
     }
+  },
+
+  // Account trade component
+  accountTrade: {
+    side: {
+      buy: 'Acheté',
+      sell: 'Vendu'
+    },
+    subheader: 'en',
+    status: 'Statut',
+    placed: 'Mis',
+    finalized: 'Finalisé',
+    date: 'Date',
+    fee: 'Frais',
+    order: 'Identifiant commercial',
+
+    message: 'Your order has been placed, thank you.',
+    purchased: 'Purchased',
+    sold: 'Sold',
+    loading: 'Submitting Crypto Order',
+    error: 'Error fetching trade'
   },
 
   // Paginator

--- a/library/src/shared/services/config/config.service.spec.ts
+++ b/library/src/shared/services/config/config.service.spec.ts
@@ -63,6 +63,22 @@ describe('ConfigService', () => {
     TestConstants.CONFIG.refreshInterval = 5000;
   }));
 
+  it('should set component$ with a component selector when setConfig() is called', () => {
+    service.setComponent('test');
+
+    service.component$.subscribe((component) => {
+      expect(component).toEqual('test');
+    });
+  });
+
+  it('should return the component as an observable ig getComponent$ is called', () => {
+    service.setComponent('test');
+
+    service.getComponent$().subscribe((component) => {
+      expect(component).toEqual('test');
+    });
+  });
+
   it('should output an error and event if setConfig() is given an invalid config', () => {
     const invalidConfig = {
       error: 'error'

--- a/library/src/shared/services/config/config.service.ts
+++ b/library/src/shared/services/config/config.service.ts
@@ -24,6 +24,8 @@ export class ConfigService implements OnDestroy {
   config: ComponentConfig = Constants.DEFAULT_CONFIG;
   config$ = new ReplaySubject<ComponentConfig>(1);
 
+  component$ = new ReplaySubject<string>(1);
+
   private unsubscribe$ = new Subject();
 
   constructor(
@@ -64,6 +66,14 @@ export class ConfigService implements OnDestroy {
 
   getConfig$(): Observable<ComponentConfig> {
     return this.config$.asObservable();
+  }
+
+  setComponent(selector: string) {
+    this.component$.next(selector);
+  }
+
+  getComponent$(): Observable<string> {
+    return this.component$.asObservable();
   }
 
   validateConfig(hostConfig: object): hostConfig is ComponentConfig {

--- a/library/src/shared/services/routing/routing.service.spec.ts
+++ b/library/src/shared/services/routing/routing.service.spec.ts
@@ -21,7 +21,10 @@ describe('RoutingService', () => {
 
   let MockEventService = jasmine.createSpyObj('EventService', ['handleEvent']);
 
-  let MockConfigService = jasmine.createSpyObj('ConfigService', ['getConfig$']);
+  let MockConfigService = jasmine.createSpyObj('ConfigService', [
+    'getConfig$',
+    'setComponent'
+  ]);
 
   let MockTranslateService = jasmine.createSpyObj('TranslateService', [
     'setTranslation',

--- a/library/src/shared/services/routing/routing.service.ts
+++ b/library/src/shared/services/routing/routing.service.ts
@@ -38,6 +38,8 @@ export class RoutingService {
               }
             );
 
+            this.configService.setComponent(routingData.route);
+
             this.router.navigate([path], routingData.extras).then(() => {
               this.eventService.handleEvent(
                 LEVEL.INFO,

--- a/library/src/shared/styles/theme.scss
+++ b/library/src/shared/styles/theme.scss
@@ -222,6 +222,14 @@ $light-theme: mat.define-light-theme(
     margin: 0;
   }
 
+  .cybrid-strong {
+    font-weight: 500;
+  }
+
+  .cybrid-no-margin {
+    margin: 0;
+  }
+
   .cybrid-pointer {
     cursor: pointer;
   }

--- a/src/demo/components/app/app.component.html
+++ b/src/demo/components/app/app.component.html
@@ -6,10 +6,7 @@
     "
   >
     <mat-toolbar color="primary">
-      <img
-        [src]="CybridLogo"
-        alt="Cybrid logo"
-      />
+      <img [src]="CybridLogo" alt="Cybrid logo" />
       <div class="spacer"></div>
       <a
         class="mat-body package"


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [X] Feature
- [ ] Bug fix

### Linked issue
- [X] Not tracked

### Why
We need e2e to finish out the account-details component.

### How
Added e2e tests.

Also included:
- Style updates to current iteration of the account-list and details view
- New component observable in the config service to allow for extending components

<img width="735" alt="Screen Shot 2022-08-19 at 1 47 10 PM" src="https://user-images.githubusercontent.com/5817894/185677983-d71d902d-ff5c-43f0-9dd7-38e5d1c211b7.png">

<img width="390" alt="Screen Shot 2022-08-19 at 1 47 24 PM" src="https://user-images.githubusercontent.com/5817894/185678027-371599e4-7c1a-4e90-8d87-c706844d51ca.png">

<img width="349" alt="Screen Shot 2022-08-19 at 1 47 41 PM" src="https://user-images.githubusercontent.com/5817894/185678048-8cbdfd4d-fc68-4f4a-bd0c-cd7f43c3c837.png">
