### PR TITLE
chore: add check for Persona version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,15 +44,15 @@ jobs:
       - image: cimg/node:16.18.0
     working_directory: ~/project
     steps:
-      - checkout
       - run:
           name: Check Persona version
           command: |
             export LATEST=$(curl https://registry.npmjs.org/persona/latest | jq -r '. | .version')
-            if [ "$LATEST"  = "$PERSONA_VERSION" ]; then
+            export CURRENT=$(grep 'PERSONA' -A 1 library/src/shared/constants/constants.ts | grep 'https' | sed 's/.*-v\(.*\).js.*/\1/')
+            if [ "$LATEST"  = "$CURRENT" ]; then
               echo "Persona is up to date."
             else
-              echo "New Persona version available"
+              echo "Error: new Persona version available."
               exit 1
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
       - image: cimg/node:16.18.0
     working_directory: ~/project
     steps:
+      - checkout
       - run:
           name: Check Persona version
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           command: |
             export LATEST=$(curl https://registry.npmjs.org/persona/latest | jq -r '. | .version')
             export CURRENT=$(grep 'PERSONA' -A 1 library/src/shared/constants/constants.ts | grep 'https' | sed 's/.*-v\(.*\).js.*/\1/')
-            if [ "$LATEST"  = "$CURRENT" ]; then
+            if [ "$LATEST" = "$CURRENT" ]; then
               echo "Persona is up to date."
             else
               echo "Error: new Persona version available."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,23 @@ jobs:
           name: Publish library
           command: npm run publish:library
 
+  check-versions:
+    docker:
+      - image: cimg/node:16.18.0
+    working_directory: ~/project
+    steps:
+      - checkout
+      - run:
+          name: Check Persona version
+          command: |
+            export LATEST=$(curl https://registry.npmjs.org/persona/latest | jq -r '. | .version')
+            if [ "$LATEST"  = "$PERSONA_VERSION" ]; then
+              echo "Persona is up to date."
+            else
+              echo "New Persona version available"
+              exit 1
+            fi
+
   deploy-demo:
     docker:
       - image: cimg/node:16.18.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,7 @@ jobs:
 workflows:
   web-build-and-test:
     jobs:
+      - check-versions
       - node/test:
           name: test
           version: 16.14.2-browsers


### PR DESCRIPTION
### Type of change

- [X] Chore
- [ ] Feature
- [ ] Bug fix

### Linked issue
https://cybrid.atlassian.net/browse/CYB-833

### Why
We need to know if the Persona client (CDN) has been updated.

### How
By adding a Circle CI step that checks the latest Persona version on NPMJS (an assumption is made here that versions will match the CDN) and checks it against the applications current version. 