### PR TITLE
chore: audit fix for socket.io dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13150,9 +13150,9 @@
       "dev": true
     },
     "node_modules/socket.io-parser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
-      "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.5.tgz",
+      "integrity": "sha512-sNjbT9dX63nqUFIOv95tTVm6elyIU4RvB1m8dOeZt+IgWwcWklFDOdmGcfo3zSiRsnR/3pJkjY5lfoGqEe4Eig==",
       "dev": true,
       "dependencies": {
         "@types/component-emitter": "^1.2.10",
@@ -24359,9 +24359,9 @@
       "dev": true
     },
     "socket.io-parser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
-      "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.5.tgz",
+      "integrity": "sha512-sNjbT9dX63nqUFIOv95tTVm6elyIU4RvB1m8dOeZt+IgWwcWklFDOdmGcfo3zSiRsnR/3pJkjY5lfoGqEe4Eig==",
       "dev": true,
       "requires": {
         "@types/component-emitter": "^1.2.10",


### PR DESCRIPTION
### Type of change

- [X] Chore
- [ ] Feature
- [ ] Bug fix

### Linked issue

- [X] Not tracked

### Why

> Explain why this PR is required
Dependency for socket.io-parser was flagged by `npm audit` causing builds to fail in testing.

> Explain how this PR addresses the why
Applied `npm audit fix` to fix the vulnerability.