### PR TITLE
feat: add instant login to web demo

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -4,14 +4,19 @@ on:
   repository_dispatch:
     types: deploy
 jobs:
-  build-and-delpoy:
+  build-and-deploy:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
+      - name: Update public demo credentials
+        run: |
+          cd src/environments && \
+          contents="$(jq -r --arg id "$cypress_CLIENT_ID_BACKSTOPPED" --arg secret "$cypress_CLIENT_SECRET_BACKSTOPPED" --arg customer "$cypress_CUSTOMER_GUID_BACKSTOPPED" '.environment.credentials.publicCustomerGuid=$customer | .environment.credentials.publicClientId=$id | .environment.credentials.publicClientSecret=$secret' environment.ci.json)" && \
+          echo "${contents}" > environment.ci.json \ &&
+          cd ...
       - name: Install and Build
         run: |
           npm ci

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -13,10 +13,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Update public demo credentials
         run: |
-          cd src/environments && \
-          contents="$(jq -r --arg id "$cypress_CLIENT_ID_BACKSTOPPED" --arg secret "$cypress_CLIENT_SECRET_BACKSTOPPED" --arg customer "$cypress_CUSTOMER_GUID_BACKSTOPPED" '.environment.credentials.publicCustomerGuid=$customer | .environment.credentials.publicClientId=$id | .environment.credentials.publicClientSecret=$secret' environment.ci.json)" && \
-          echo "${contents}" > environment.ci.json \ &&
-          cd ...
+          contents="$(jq -r --arg id "$cypress_CLIENT_ID_BACKSTOPPED" --arg secret "$cypress_CLIENT_SECRET_BACKSTOPPED" --arg customer "$cypress_CUSTOMER_GUID_BACKSTOPPED" '.environment.credentials.publicCustomerGuid=$customer | .environment.credentials.publicClientId=$id | .environment.credentials.publicClientSecret=$secret' src/environments/environment.ci.json)" && \
+          echo "${contents}" > src/environments/environment.ci.json
       - name: Install and Build
         run: |
           npm ci

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -10,7 +10,10 @@ export default defineConfig({
   env: {
     CLIENT_ID: '',
     CLIENT_SECRET: '',
-    CUSTOMER_GUID: ''
+    CUSTOMER_GUID: '',
+    CLIENT_ID_BACKSTOPPED: '',
+    CLIENT_SECRET_BACKSTOPPED: '',
+    CUSTOMER_GUID_BACKSTOPPED: ''
   },
   e2e: {
     baseUrl: 'http://localhost:4200'

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -8,9 +8,9 @@ export default defineConfig({
   defaultCommandTimeout: 10000,
   requestTimeout: 15000,
   env: {
-    CLIENT_ID: '',
-    CLIENT_SECRET: '',
-    CUSTOMER_GUID: '',
+    CLIENT_ID_PLAID: '',
+    CLIENT_SECRET_PLAID: '',
+    CUSTOMER_GUID_PLAID: '',
     CLIENT_ID_BACKSTOPPED: '',
     CLIENT_SECRET_BACKSTOPPED: '',
     CUSTOMER_GUID_BACKSTOPPED: ''

--- a/cypress/e2e/login.cy.ts
+++ b/cypress/e2e/login.cy.ts
@@ -8,9 +8,9 @@ describe('login test', () => {
     // Navigate to login
     cy.visit('/');
 
-    app().should('exist').get('#clientId').type(Cypress.env('CLIENT_ID'));
-    app().get('#clientSecret').type(Cypress.env('CLIENT_SECRET'));
-    app().get('#customerGuid').type(Cypress.env('CUSTOMER_GUID'));
+    app().should('exist').get('#clientId').type(Cypress.env('CLIENT_ID_PLAID'));
+    app().get('#clientSecret').type(Cypress.env('CLIENT_SECRET_PLAID'));
+    app().get('#customerGuid').type(Cypress.env('CUSTOMER_GUID_PLAID'));
     app().get('#login').click();
   });
 });

--- a/cypress/e2e/trade.cy.ts
+++ b/cypress/e2e/trade.cy.ts
@@ -185,20 +185,14 @@ describe('trade test', () => {
   });
 
   it('should display the order summary', () => {
-    cy.intercept('GET', '/api/trades/*', (req) => {
-      req.reply(TestConstants.TRADE_BANK_MODEL);
-    }).as('getTrade');
-
     // Check order submitted dialog
-    cy.wait('@getTrade').then(() => {
-      app()
-        .get('app-trade-summary')
-        .find('.cybrid-list-item')
-        .should('contain.text', 'Purchased')
-        .should('contain.text', 'ETH')
-        .should('contain.text', 'USD')
-        .should('contain.text', '$1.00');
-    });
+    app()
+      .get('app-trade-summary')
+      .find('.cybrid-list-item')
+      .should('contain.text', 'Purchased')
+      .should('contain.text', 'ETH')
+      .should('contain.text', 'USD')
+      .should('contain.text', '$1.00');
   });
 
   it('should exit the dialog and navigate to the price-list on done', () => {

--- a/cypress/e2e/trade.cy.ts
+++ b/cypress/e2e/trade.cy.ts
@@ -12,7 +12,7 @@ describe('trade test', () => {
   before(() => {
     cy.visit('/');
     // @ts-ignore
-    cy.login();
+    cy.login('backstopped');
   });
   it('should render the trade component', () => {
     tradeSetup();
@@ -185,14 +185,20 @@ describe('trade test', () => {
   });
 
   it('should display the order summary', () => {
+    cy.intercept('GET', '/api/trades/*', (req) => {
+      req.reply(TestConstants.TRADE_BANK_MODEL);
+    }).as('getTrade');
+
     // Check order submitted dialog
-    app()
-      .get('app-trade-summary')
-      .find('.cybrid-list-item')
-      .should('contain.text', 'Purchased')
-      .should('contain.text', 'ETH')
-      .should('contain.text', 'USD')
-      .should('contain.text', '$1,033.31');
+    cy.wait('@getTrade').then(() => {
+      app()
+        .get('app-trade-summary')
+        .find('.cybrid-list-item')
+        .should('contain.text', 'Purchased')
+        .should('contain.text', 'ETH')
+        .should('contain.text', 'USD')
+        .should('contain.text', '$1.00');
+    });
   });
 
   it('should exit the dialog and navigate to the price-list on done', () => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -14,7 +14,7 @@ function customCommand(param: any): void {
 }
 
 // @ts-ignore
-Cypress.Commands.add('login', () => {
+Cypress.Commands.add('login', (backstopped?: 'backstopped') => {
   cy.intercept(
     'GET',
     'https://api.github.com/repos/Cybrid-app/cybrid-sdk-web/releases/latest',
@@ -24,13 +24,28 @@ Cypress.Commands.add('login', () => {
   );
 
   cy.visit('/');
-  cy.get('app-login')
-    .should('exist')
-    .get('#clientId')
-    .type(Cypress.env('CLIENT_ID'));
-  cy.get('#clientSecret').type(Cypress.env('CLIENT_SECRET'));
-  cy.get('#customerGuid').type(Cypress.env('CUSTOMER_GUID'));
-  cy.get('#login').click();
+
+  function typeCredentials(
+    client_id: string,
+    client_secret: string,
+    customer_guid: string
+  ) {
+    cy.get('app-login')
+      .should('exist')
+      .get('#clientId')
+      .type(Cypress.env(client_id));
+    cy.get('#clientSecret').type(Cypress.env(client_secret));
+    cy.get('#customerGuid').type(Cypress.env(customer_guid));
+    cy.get('#login').click();
+  }
+
+  backstopped
+    ? typeCredentials(
+        'CLIENT_ID_BACKSTOPPED',
+        'CLIENT_SECRET_BACKSTOPPED',
+        'CUSTOMER_GUID_BACKSTOPPED'
+      )
+    : typeCredentials('CLIENT_ID', 'CLIENT_SECRET', 'CUSTOMER_GUID');
 });
 //
 // NOTE: You can use it like so:

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -45,7 +45,11 @@ Cypress.Commands.add('login', (backstopped?: 'backstopped') => {
         'CLIENT_SECRET_BACKSTOPPED',
         'CUSTOMER_GUID_BACKSTOPPED'
       )
-    : typeCredentials('CLIENT_ID', 'CLIENT_SECRET', 'CUSTOMER_GUID');
+    : typeCredentials(
+        'CLIENT_ID_PLAID',
+        'CLIENT_SECRET_PLAID',
+        'CUSTOMER_GUID_PLAID'
+      );
 });
 //
 // NOTE: You can use it like so:

--- a/library/src/shared/constants/test.constants.ts
+++ b/library/src/shared/constants/test.constants.ts
@@ -118,18 +118,18 @@ export class TestConstants {
   };
 
   static TRADE_BANK_MODEL: TradeBankModel = {
-    guid: 'f21f8cf0bcb30fad80db7a04edebdff0',
-    customer_guid: 'c6cce7287f22d1fd8b38765cba0d5bf2',
-    quote_guid: 'dac5e23b30d81ad2fb290b4a6c3bbb7b',
+    guid: 'c82a16d42415867e8d740cb1691b5af5',
+    customer_guid: 'a770abcb07ba7be59bbda2e75be19e66',
+    quote_guid: '99914bf69eec4b2007407dfa92936320',
     symbol: 'ETH-USD',
     side: 'buy',
     state: 'settling',
-    // @ts-ignore
+    //@ts-ignore
     failure_code: null,
-    receive_amount: '863431100000000',
+    receive_amount: '860900000000000',
     deliver_amount: '100',
     fee: '0',
-    created_at: '2022-11-23T14:28:28.223Z'
+    created_at: '2022-11-23T15:59:26.073Z'
   };
 
   // Account-list component test models

--- a/library/src/shared/constants/test.constants.ts
+++ b/library/src/shared/constants/test.constants.ts
@@ -118,18 +118,18 @@ export class TestConstants {
   };
 
   static TRADE_BANK_MODEL: TradeBankModel = {
-    guid: '3a1afe49232332f69d8c52f1157fdf81',
-    customer_guid: '',
-    quote_guid: 'ede5f73db305fbd27ec0eb0894ae8aa7',
+    guid: 'f21f8cf0bcb30fad80db7a04edebdff0',
+    customer_guid: 'c6cce7287f22d1fd8b38765cba0d5bf2',
+    quote_guid: 'dac5e23b30d81ad2fb290b4a6c3bbb7b',
     symbol: 'ETH-USD',
     side: 'buy',
-    state: 'storing',
+    state: 'settling',
     // @ts-ignore
     failure_code: null,
-    receive_amount: '1000000000000000000',
-    deliver_amount: '103331',
+    receive_amount: '863431100000000',
+    deliver_amount: '100',
     fee: '0',
-    created_at: '2022-06-30T17:04:39.049Z'
+    created_at: '2022-11-23T14:28:28.223Z'
   };
 
   // Account-list component test models

--- a/src/demo/components/demo/demo.component.html
+++ b/src/demo/components/demo/demo.component.html
@@ -20,12 +20,18 @@
           id="option"
           *ngFor="let component of webComponents"
           [value]="component"
-          [disabled]="component === 'account-details'"
+          [disabled]="
+            component === 'account-details' ||
+            (isPublic && component === 'identity-verification')
+          "
           matTooltipPosition="before"
           [matTooltip]="
-            component === 'account-details'
+            (component === 'account-details'
               ? 'Disabled: Navigate via account-list'
-              : ''
+              : '') ||
+            (isPublic && component === 'identity-verification'
+              ? 'Disabled: Sign in as a private use to access'
+              : '')
           "
         >
           {{ component }}

--- a/src/demo/components/demo/demo.component.ts
+++ b/src/demo/components/demo/demo.component.ts
@@ -29,6 +29,7 @@ export class DemoComponent implements OnDestroy {
   public viewContainer!: ViewContainerRef;
 
   token = '';
+  isPublic: boolean = false;
 
   webComponents = [
     'price-list',
@@ -104,6 +105,9 @@ export class DemoComponent implements OnDestroy {
     this.componentRef.instance.hostConfig = config;
     this.componentRef.instance.auth = credentials.token;
     this.componentRef.instance.component = Constants.DEFAULT_COMPONENT;
+
+    // Set Public/Private
+    this.isPublic = credentials.isPublic;
 
     // Subscribe to component configuration changes
     this.demoConfigService.config$

--- a/src/demo/components/login/login.component.html
+++ b/src/demo/components/login/login.component.html
@@ -94,6 +94,13 @@
     </mat-card-content>
     <mat-card-actions>
       <button
+        id="publicLogin"
+        mat-stroked-button
+        (click)="login(true)"
+      >
+        Public User
+      </button>
+      <button
         id="login"
         [disabled]="loginForm.invalid"
         mat-flat-button

--- a/src/demo/components/login/login.component.html
+++ b/src/demo/components/login/login.component.html
@@ -99,7 +99,7 @@
         color="primary"
         (click)="login(true)"
       >
-        Instant Login
+        Instant Demo
       </button>
       <button
         id="login"

--- a/src/demo/components/login/login.component.html
+++ b/src/demo/components/login/login.component.html
@@ -95,10 +95,11 @@
     <mat-card-actions>
       <button
         id="publicLogin"
-        mat-stroked-button
+        mat-flat-button
+        color="primary"
         (click)="login(true)"
       >
-        Public User
+        Instant Login
       </button>
       <button
         id="login"

--- a/src/demo/components/login/login.component.scss
+++ b/src/demo/components/login/login.component.scss
@@ -37,6 +37,8 @@
   mat-card-actions {
     display: flex;
     justify-content: center;
+    gap: 0.5rem;
+
     button {
       min-width: 200px;
     }

--- a/src/demo/components/login/login.component.ts
+++ b/src/demo/components/login/login.component.ts
@@ -50,8 +50,7 @@ export class LoginComponent implements OnInit {
   constructor(
     private http: HttpClient,
     private configService: DemoConfigService
-  ) {
-  }
+  ) {}
 
   ngOnInit() {
     this.initLoginForm();
@@ -123,18 +122,18 @@ export class LoginComponent implements OnInit {
         return this.bearer
           ? of(this.loginForm.controls.bearerToken.value)
           : this.configService
-            .createToken(
-              this.loginForm.value.clientId,
-              this.loginForm.value.clientSecret
-            )
-            .pipe(
-              catchError((err) => {
-                this.loginForm.controls.clientId.setErrors({
-                  unauthorized: true
-                });
-                return of(err);
-              })
-            );
+              .createToken(
+                this.loginForm.value.clientId,
+                this.loginForm.value.clientSecret
+              )
+              .pipe(
+                catchError((err) => {
+                  this.loginForm.controls.clientId.setErrors({
+                    unauthorized: true
+                  });
+                  return of(err);
+                })
+              );
       }
     };
 

--- a/src/demo/components/login/login.component.ts
+++ b/src/demo/components/login/login.component.ts
@@ -43,9 +43,9 @@ export class LoginComponent implements OnInit {
   };
 
   // PUBLIC CREDENTIALS FOR NO-LOGIN DEMO
-  readonly publicClientId = 'gtlpql9qUwhhhRBKemkWG2aIofhUZBf-J_1QY-nsNg8';
-  readonly publicClientSecret = '2eEo_u3MYyzawlB7Cm4-mP397EzOz5tAZwQFTiF6EKc';
-  readonly publicCustomerGuid = '72892100b5fdd31a1bf7a3c341e64cb8';
+  readonly publicClientId = environment.credentials.publicClientId;
+  readonly publicClientSecret = environment.credentials.publicClientSecret;
+  readonly publicCustomerGuid = environment.credentials.publicCustomerGuid;
 
   loginForm!: FormGroup<LoginForm>;
 

--- a/src/demo/components/login/login.component.ts
+++ b/src/demo/components/login/login.component.ts
@@ -23,6 +23,7 @@ interface LoginForm {
 export interface DemoCredentials {
   token: string;
   customer: string;
+  isPublic: boolean;
 }
 
 @Component({
@@ -37,7 +38,8 @@ export class LoginComponent implements OnInit {
   bearer = false;
   demoCredentials: DemoCredentials = {
     token: '',
-    customer: ''
+    customer: '',
+    isPublic: false
   };
 
   // PUBLIC CREDENTIALS FOR NO-LOGIN DEMO
@@ -193,6 +195,11 @@ export class LoginComponent implements OnInit {
       .subscribe((customer: CustomerBankModel) => {
         if (customer.guid) {
           this.demoCredentials.customer = customer.guid;
+
+          publicUser
+            ? (this.demoCredentials.isPublic = publicUser)
+            : (this.demoCredentials.isPublic = false);
+
           this.credentials.next(this.demoCredentials);
         }
       });

--- a/src/environments/environment.ci.json
+++ b/src/environments/environment.ci.json
@@ -1,0 +1,12 @@
+{
+  "environment": {
+    "credentials": {
+      "clientSecret": "",
+      "clientId": "",
+      "customerGuid": "",
+      "publicClientId": "",
+      "publicClientSecret": "",
+      "publicCustomerGuid": ""
+    }
+  }
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,12 +1,14 @@
+/*
+ * CircleCi friendly json used to update public user keys
+ * (for instant demo) when building the production web demo
+ */
+import * as ci from './environment.ci.json';
+
 export const environment = {
-  production: false,
+  production: true,
   authUrl: 'https://id.demo.cybrid.app/oauth/token',
-  credentials: {
-    clientId: '',
-    clientSecret: '',
-    customerGuid: ''
-  },
   grant_type: 'client_credentials',
+  credentials: ci.environment.credentials,
   scope:
     'banks:read banks:write accounts:read accounts:execute customers:read customers:write customers:execute prices:read quotes:execute trades:execute trades:read external_bank_accounts:read external_bank_accounts:execute workflows:read workflows:execute'
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -2,7 +2,7 @@
  * CircleCi friendly json used to update public user keys
  * (for instant demo) when building the production web demo
  */
-import * as ci from './environment.ci.json';
+import ci from './environment.ci.json';
 
 export const environment = {
   production: true,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -12,7 +12,10 @@ export const environment = {
   credentials: {
     clientId: '',
     clientSecret: '',
-    customerGuid: ''
+    customerGuid: '',
+    publicClientId: '',
+    publicClientSecret: '',
+    publicCustomerGuid: ''
   },
   grant_type: 'client_credentials',
   scope:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "declaration": false,
     "downlevelIteration": true,
     "experimentalDecorators": true,
+    "resolveJsonModule": true,
     "moduleResolution": "node",
     "importHelpers": true,
     "target": "es2020",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "downlevelIteration": true,
     "experimentalDecorators": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "moduleResolution": "node",
     "importHelpers": true,
     "target": "es2020",


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [X] Feature
- [ ] Bug fix

### Linked issue
https://cybrid.atlassian.net/browse/CYB-861

### Why
We want to have a public user to demo our web components.

### How
By adding an instant demo button tied to a specific public user.

Also includes credentials for a newly generated backstopped bank that is used for trade testing in e2e.