### PR TITLE
fix: add missing Github env secrets

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -8,12 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CLIENT_ID: ${{ secrets.CYPRESS_CLIENT_ID_BACKSTOPPED }}
+      CLIENT_SECRET: ${{ secrets.CYPRESS_CLIENT_SECRET_BACKSTOPPED }}
+      CUSTOMER_GUID: ${{ secrets.CYPRESS_CUSTOMER_GUID_BACKSTOPPED }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Update public demo credentials
         run: |
-          contents="$(jq -r --arg id "$cypress_CLIENT_ID_BACKSTOPPED" --arg secret "$cypress_CLIENT_SECRET_BACKSTOPPED" --arg customer "$cypress_CUSTOMER_GUID_BACKSTOPPED" '.environment.credentials.publicCustomerGuid=$customer | .environment.credentials.publicClientId=$id | .environment.credentials.publicClientSecret=$secret' src/environments/environment.ci.json)" && \
+          contents="$(jq -r --arg id "$CLIENT_ID" --arg secret "$CLIENT_SECRET" --arg customer "$CUSTOMER_GUID" '.environment.credentials.publicCustomerGuid=$customer | .environment.credentials.publicClientId=$id | .environment.credentials.publicClientSecret=$secret' src/environments/environment.ci.json)" && \
           echo "${contents}" > src/environments/environment.ci.json
       - name: Install and Build
         run: |


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [X] Bug fix

### Linked issue
- [X] Not tracked

### Why
Instant demo login credentials were missing from the Github Actions `env`.

### How
Added the missing variables.