### PR TITLE
feat: add production input, and login control

### DIFF
--- a/library/src/app/components/app/app.component.spec.ts
+++ b/library/src/app/components/app/app.component.spec.ts
@@ -85,8 +85,7 @@ describe('AppComponent', () => {
         { provide: ConfigService, useValue: MockConfigService },
         { provide: Configuration, useClass: MockConfiguration },
         { provide: RoutingService, useValue: MockRoutingService },
-        { provide: Router, useValue: MockRouter },
-        Configuration
+        { provide: Router, useValue: MockRouter }
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
@@ -122,19 +121,6 @@ describe('AppComponent', () => {
     expect(MockAuthService.setToken).toHaveBeenCalledWith(testToken);
     flushMicrotasks();
   }));
-
-  it('should set the environment to production', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const component = fixture.componentInstance;
-
-    // Default
-    expect(component.configuration.basePath).toBeUndefined();
-
-    component.production = true;
-    expect(component.configuration.basePath).toEqual(
-      environment.productionBankApiBasePath
-    );
-  });
 
   it('should set the config', fakeAsync(() => {
     const fixture = TestBed.createComponent(AppComponent);

--- a/library/src/app/components/app/app.component.spec.ts
+++ b/library/src/app/components/app/app.component.spec.ts
@@ -24,9 +24,14 @@ import {
   ConfigService,
   RoutingService
 } from '@services';
+import { Configuration } from '@cybrid/cybrid-api-bank-angular';
 
+// Components
 import { AppComponent } from '@components';
+
+// Utility
 import { Constants, TestConstants } from '@constants';
+import { environment } from '@environment';
 
 describe('AppComponent', () => {
   let MockAuthService = jasmine.createSpyObj('AuthService', [
@@ -57,6 +62,10 @@ describe('AppComponent', () => {
   ]);
   let MockRouter = jasmine.createSpyObj('Router', ['navigate']);
 
+  class MockConfiguration extends Configuration {
+    override basePath = environment.sandboxBankApiBasePath;
+  }
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
@@ -74,8 +83,10 @@ describe('AppComponent', () => {
         { provide: EventService, useValue: MockEventService },
         { provide: ErrorService, useValue: MockErrorService },
         { provide: ConfigService, useValue: MockConfigService },
+        { provide: Configuration, useClass: MockConfiguration },
         { provide: RoutingService, useValue: MockRoutingService },
-        { provide: Router, useValue: MockRouter }
+        { provide: Router, useValue: MockRouter },
+        Configuration
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
@@ -111,6 +122,19 @@ describe('AppComponent', () => {
     expect(MockAuthService.setToken).toHaveBeenCalledWith(testToken);
     flushMicrotasks();
   }));
+
+  it('should set the environment to production', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const component = fixture.componentInstance;
+
+    // Default
+    expect(component.configuration.basePath).toBeUndefined();
+
+    component.production = true;
+    expect(component.configuration.basePath).toEqual(
+      environment.productionBankApiBasePath
+    );
+  });
 
   it('should set the config', fakeAsync(() => {
     const fixture = TestBed.createComponent(AppComponent);

--- a/library/src/app/components/app/app.component.ts
+++ b/library/src/app/components/app/app.component.ts
@@ -36,9 +36,6 @@ import {
 } from '@services';
 import { Configuration } from '@cybrid/cybrid-api-bank-angular';
 
-// Utility
-import { environment } from '@environment';
-
 @Component({
   selector: 'app-app',
   templateUrl: './app.component.html',
@@ -49,15 +46,6 @@ export class AppComponent implements OnInit {
   @Output() eventLog = new EventEmitter<EventLog>();
   @Output() errorLog = new EventEmitter<ErrorLog>();
 
-  /**
-   * Sets the environment to production
-   * The Bank client is configured by default with the demo environment base path
-   * */
-  @Input()
-  set production(prod: boolean) {
-    if (prod)
-      this.configuration.basePath = environment.productionBankApiBasePath;
-  }
   @Input()
   set auth(token: string) {
     this.authService.setToken(token);

--- a/library/src/app/components/app/app.component.ts
+++ b/library/src/app/components/app/app.component.ts
@@ -34,6 +34,10 @@ import {
   CODE,
   LEVEL
 } from '@services';
+import { Configuration } from '@cybrid/cybrid-api-bank-angular';
+
+// Utility
+import { environment } from '@environment';
 
 @Component({
   selector: 'app-app',
@@ -44,6 +48,16 @@ import {
 export class AppComponent implements OnInit {
   @Output() eventLog = new EventEmitter<EventLog>();
   @Output() errorLog = new EventEmitter<ErrorLog>();
+
+  /**
+   * Sets the environment to production
+   * The Bank client is configured by default with the demo environment base path
+   * */
+  @Input()
+  set production(prod: boolean) {
+    if (prod)
+      this.configuration.basePath = environment.productionBankApiBasePath;
+  }
   @Input()
   set auth(token: string) {
     this.authService.setToken(token);
@@ -61,6 +75,7 @@ export class AppComponent implements OnInit {
   unsubscribe$ = new Subject();
 
   constructor(
+    public configuration: Configuration,
     private router: Router,
     private authService: AuthService,
     private assetService: AssetService,

--- a/library/src/app/components/navigation/navigation.component.spec.ts
+++ b/library/src/app/components/navigation/navigation.component.spec.ts
@@ -8,6 +8,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { RoutingData, RoutingService } from '@services';
+import { Configuration } from '@cybrid/cybrid-api-bank-angular';
 
 describe('NavigationComponent', () => {
   let component: NavigationComponent;
@@ -31,7 +32,10 @@ describe('NavigationComponent', () => {
           }
         })
       ],
-      providers: [{ provide: RoutingService, useValue: MockRoutingService }],
+      providers: [
+        { provide: RoutingService, useValue: MockRoutingService },
+        Configuration
+      ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
 

--- a/library/src/app/components/transfer/transfer-details/transfer-details.component.spec.ts
+++ b/library/src/app/components/transfer/transfer-details/transfer-details.component.spec.ts
@@ -16,6 +16,9 @@ import {
   MatDialogRef
 } from '@angular/material/dialog';
 
+// Services
+import { Configuration } from '@cybrid/cybrid-api-bank-angular';
+
 // Components
 import { TransferDetailsComponent, TransferDetailsData } from '@components';
 
@@ -64,7 +67,8 @@ describe('TransferDetailsComponent', () => {
         },
         { provide: AssetPipe, useClass: MockAssetPipe },
         TruncatePipe,
-        TranslatePipe
+        TranslatePipe,
+        Configuration
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();

--- a/library/src/app/modules/library.module.ts
+++ b/library/src/app/modules/library.module.ts
@@ -66,7 +66,6 @@ import {
 } from '@components';
 
 // Utility
-import { environment } from '@environment';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { AssetPipe, TruncatePipe } from '@pipes';
 import { MatPaginatorIntl } from '@angular/material/paginator';
@@ -121,7 +120,6 @@ export function HttpLoaderFactory(http: HttpClient) {
       provide: Configuration,
       useFactory: (authService: AuthService) =>
         new Configuration({
-          basePath: environment.apiUrl,
           credentials: {
             BearerAuth: authService.getToken.bind(authService)
           }

--- a/library/src/environments/environment.prod.ts
+++ b/library/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
-  apiUrl: 'https://bank.demo.cybrid.app'
+  sandboxBankApiBasePath: 'https://bank.demo.cybrid.app',
+  productionBankApiBasePath: 'https://bank.production.cybrid.app'
 };

--- a/library/src/environments/environment.prod.ts
+++ b/library/src/environments/environment.prod.ts
@@ -1,5 +1,7 @@
 export const environment = {
   production: true,
-  sandboxBankApiBasePath: 'https://bank.demo.cybrid.app',
+  demoBankApiBasePath: 'https://bank.demo.cybrid.app',
+  stagingBankApiBasePath: 'https://bank.staging.cybrid.app',
+  sandboxBankApiBasePath: 'https://bank.sandbox.cybrid.app',
   productionBankApiBasePath: 'https://bank.production.cybrid.app'
 };

--- a/library/src/environments/environment.ts
+++ b/library/src/environments/environment.ts
@@ -4,7 +4,9 @@
 
 export const environment = {
   production: false,
-  sandboxBankApiBasePath: 'https://bank.demo.cybrid.app',
+  demoBankApiBasePath: 'https://bank.demo.cybrid.app',
+  stagingBankApiBasePath: 'https://bank.staging.cybrid.app',
+  sandboxBankApiBasePath: 'https://bank.sandbox.cybrid.app',
   productionBankApiBasePath: 'https://bank.production.cybrid.app'
 };
 

--- a/library/src/environments/environment.ts
+++ b/library/src/environments/environment.ts
@@ -4,7 +4,8 @@
 
 export const environment = {
   production: false,
-  apiUrl: 'https://bank.demo.cybrid.app'
+  sandboxBankApiBasePath: 'https://bank.demo.cybrid.app',
+  productionBankApiBasePath: 'https://bank.production.cybrid.app'
 };
 
 /*

--- a/library/src/shared/constants/constants.ts
+++ b/library/src/shared/constants/constants.ts
@@ -51,7 +51,7 @@ export class Constants {
     routing: Constants.ROUTING,
     customer: '',
     fiat: 'USD',
-    environment: 'sandbox'
+    environment: 'demo'
   };
   static DEFAULT_COMPONENT = 'price-list';
   static POLL_DURATION = 5000;

--- a/library/src/shared/constants/constants.ts
+++ b/library/src/shared/constants/constants.ts
@@ -50,7 +50,8 @@ export class Constants {
     theme: Constants.THEME,
     routing: Constants.ROUTING,
     customer: '',
-    fiat: 'USD'
+    fiat: 'USD',
+    environment: 'sandbox'
   };
   static DEFAULT_COMPONENT = 'price-list';
   static POLL_DURATION = 5000;

--- a/library/src/shared/constants/test.constants.ts
+++ b/library/src/shared/constants/test.constants.ts
@@ -38,7 +38,8 @@ export class TestConstants {
     theme: 'LIGHT',
     routing: true,
     customer: '378c691c1b5ba3b938e17c1726202fe4',
-    fiat: 'USD'
+    fiat: 'USD',
+    environment: 'sandbox'
   };
 
   // Extension of AssetBankModel to include urls

--- a/library/src/shared/constants/test.constants.ts
+++ b/library/src/shared/constants/test.constants.ts
@@ -39,7 +39,7 @@ export class TestConstants {
     routing: true,
     customer: '378c691c1b5ba3b938e17c1726202fe4',
     fiat: 'USD',
-    environment: 'sandbox'
+    environment: 'demo'
   };
 
   // Extension of AssetBankModel to include urls

--- a/library/src/shared/services/config/config.service.spec.ts
+++ b/library/src/shared/services/config/config.service.spec.ts
@@ -132,19 +132,34 @@ describe('ConfigService', () => {
   });
 
   it('should set environment', () => {
-    // 'sandbox'
+    // 'demo'
     service.setEnvironment(TestConstants.CONFIG);
 
+    expect(service['configuration'].basePath).toEqual(
+      environment.demoBankApiBasePath
+    );
+
+    // 'staging'
+    let testConfig = { ...TestConstants.CONFIG };
+    testConfig.environment = 'staging';
+
+    service.setEnvironment(testConfig);
+    expect(service['configuration'].basePath).toEqual(
+      environment.stagingBankApiBasePath
+    );
+
+    // 'sandbox'
+    testConfig.environment = 'sandbox';
+
+    service.setEnvironment(testConfig);
     expect(service['configuration'].basePath).toEqual(
       environment.sandboxBankApiBasePath
     );
 
     // 'production'
-    let productionTestConfig = { ...TestConstants.CONFIG };
-    productionTestConfig.environment = 'production';
+    testConfig.environment = 'production';
 
-    service.setEnvironment(productionTestConfig);
-
+    service.setEnvironment(testConfig);
     expect(service['configuration'].basePath).toEqual(
       environment.productionBankApiBasePath
     );

--- a/library/src/shared/services/config/config.service.spec.ts
+++ b/library/src/shared/services/config/config.service.spec.ts
@@ -16,8 +16,10 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import {
   BanksService,
+  Configuration,
   CustomersService
 } from '@cybrid/cybrid-api-bank-angular';
+import { environment } from '@environment';
 
 describe('ConfigService', () => {
   let service: ConfigService;
@@ -30,6 +32,9 @@ describe('ConfigService', () => {
   ]);
   let MockCustomersService = jasmine.createSpyObj(['getCustomer']);
   let MockBanksService = jasmine.createSpyObj(['getBank']);
+  class MockConfiguration extends Configuration {
+    override basePath = environment.sandboxBankApiBasePath;
+  }
 
   // Reset config to mock prod
   TestConstants.CONFIG.customer = '';
@@ -41,6 +46,7 @@ describe('ConfigService', () => {
         { provide: ErrorService, useValue: MockErrorService },
         { provide: EventService, useValue: MockEventService },
         { provide: TranslateService, useValue: MockTranslateService },
+        { provide: Configuration, useClass: MockConfiguration },
         { provide: CustomersService, useValue: MockCustomersService },
         { provide: BanksService, useValue: MockBanksService }
       ]
@@ -123,6 +129,25 @@ describe('ConfigService', () => {
     service.getConfig$().subscribe((cfg) => {
       expect(cfg.theme).toEqual('DARK');
     });
+  });
+
+  it('should set environment', () => {
+    // 'sandbox'
+    service.setEnvironment(TestConstants.CONFIG);
+
+    expect(service['configuration'].basePath).toEqual(
+      environment.sandboxBankApiBasePath
+    );
+
+    // 'production'
+    let productionTestConfig = { ...TestConstants.CONFIG };
+    productionTestConfig.environment = 'production';
+
+    service.setEnvironment(productionTestConfig);
+
+    expect(service['configuration'].basePath).toEqual(
+      environment.productionBankApiBasePath
+    );
   });
 
   it('should fetch customer data', () => {

--- a/library/src/shared/services/config/config.service.ts
+++ b/library/src/shared/services/config/config.service.ts
@@ -37,7 +37,7 @@ export interface ComponentConfig {
   routing: boolean;
   customer: string; // Temporary solution until the JWT embeds a customer GUID
   fiat: string;
-  environment: 'sandbox' | 'production';
+  environment: 'demo' | 'staging' | 'sandbox' | 'production';
 }
 
 @Injectable({
@@ -135,6 +135,12 @@ export class ConfigService implements OnDestroy {
 
   setEnvironment(config: ComponentConfig): boolean {
     switch (config.environment) {
+      case 'demo':
+        this.configuration.basePath = environment.demoBankApiBasePath;
+        return true;
+      case 'staging':
+        this.configuration.basePath = environment.stagingBankApiBasePath;
+        return true;
       case 'sandbox':
         this.configuration.basePath = environment.sandboxBankApiBasePath;
         return true;

--- a/library/src/shared/services/routing/routing.service.spec.ts
+++ b/library/src/shared/services/routing/routing.service.spec.ts
@@ -12,6 +12,7 @@ import {
   LEVEL,
   RoutingService
 } from '@services';
+import { Configuration } from '@cybrid/cybrid-api-bank-angular';
 
 // Utility
 import { TranslateService } from '@ngx-translate/core';
@@ -43,7 +44,8 @@ describe('RoutingService', () => {
         { provide: TranslateService, useValue: MockTranslateService },
         { provide: EventService, useValue: MockEventService },
         { provide: ConfigService, useValue: MockConfigService },
-        { provide: Router, useValue: MockRouter }
+        { provide: Router, useValue: MockRouter },
+        Configuration
       ]
     });
     service = TestBed.inject(RoutingService);

--- a/src/demo/components/app/app.component.ts
+++ b/src/demo/components/app/app.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { OverlayContainer } from '@angular/cdk/overlay';
 
 import { Observable, map, pluck, take } from 'rxjs';
 
@@ -21,12 +22,15 @@ export class AppComponent {
 
   constructor(
     private http: HttpClient,
-    public demoConfigService: DemoConfigService
+    public demoConfigService: DemoConfigService,
+    private overlay: OverlayContainer
   ) {
     this.version = this.http.get(Constants.REPO_URL).pipe(
       pluck('tag_name'),
       map((tag) => tag as string)
     );
+    // Set default light theme for Angular Material CDK backdrops
+    this.overlay.getContainerElement().classList.add('cybrid-light-theme');
   }
 
   toggleTheme(): void {
@@ -35,10 +39,19 @@ export class AppComponent {
         take(1),
         map((config) => {
           let newConfig = config;
-          config.theme === 'LIGHT'
-            ? (newConfig.theme = 'DARK')
-            : (newConfig.theme = 'LIGHT');
-          this.demoConfigService.config$.next(newConfig);
+          const container = this.overlay.getContainerElement();
+
+          if (config.theme == 'DARK') {
+            newConfig.theme = 'LIGHT';
+            container.classList.remove('cybrid-dark-theme');
+            container.classList.add('cybrid-light-theme');
+            this.demoConfigService.config$.next(newConfig);
+          } else {
+            newConfig.theme = 'DARK';
+            container.classList.remove('cybrid-light-theme');
+            container.classList.add('cybrid-dark-theme');
+            this.demoConfigService.config$.next(newConfig);
+          }
         })
       )
       .subscribe();

--- a/src/demo/components/demo/demo.component.ts
+++ b/src/demo/components/demo/demo.component.ts
@@ -134,6 +134,7 @@ export class DemoComponent implements OnDestroy {
 
     let config = { ...Constants.DEFAULT_CONFIG };
     config.customer = credentials.customer;
+    config.environment = credentials.environment;
 
     this.languageGroup.patchValue({ language: config.locale });
     this.demoConfigService.config$.next(config);

--- a/src/demo/components/login/login.component.html
+++ b/src/demo/components/login/login.component.html
@@ -90,6 +90,15 @@
             Customer not found
           </mat-error>
         </mat-form-field>
+
+        <p>
+          <mat-checkbox
+            color="primary"
+            formControlName="production"
+            class="mat-hint"
+            >Enable production environment</mat-checkbox
+          >
+        </p>
       </ng-container>
     </mat-card-content>
     <mat-card-actions>

--- a/src/demo/components/login/login.component.html
+++ b/src/demo/components/login/login.component.html
@@ -91,14 +91,14 @@
           </mat-error>
         </mat-form-field>
 
-        <p>
-          <mat-checkbox
-            color="primary"
-            formControlName="production"
-            class="mat-hint"
-            >Enable production environment</mat-checkbox
-          >
-        </p>
+        <mat-form-field appearance="outline">
+          <mat-label>Environment</mat-label>
+          <mat-select formControlName="environment">
+            <mat-option *ngFor="let env of environment" [value]="env">{{
+              env | titlecase
+            }}</mat-option>
+          </mat-select>
+        </mat-form-field>
       </ng-container>
     </mat-card-content>
     <mat-card-actions>

--- a/src/demo/components/login/login.component.scss
+++ b/src/demo/components/login/login.component.scss
@@ -33,6 +33,10 @@
   mat-card-content {
     display: flex;
     flex-direction: column;
+
+    p {
+      padding-left: 0.5rem;
+    }
   }
   mat-card-actions {
     display: flex;

--- a/src/demo/components/login/login.component.ts
+++ b/src/demo/components/login/login.component.ts
@@ -18,14 +18,14 @@ interface LoginForm {
   clientSecret: FormControl<string>;
   bearerToken: FormControl<string>;
   customerGuid: FormControl<string>;
-  production: FormControl<boolean>;
+  environment: FormControl<'sandbox' | 'production'>;
 }
 
 export interface DemoCredentials {
   token: string;
   customer: string;
   isPublic: boolean;
-  production: boolean;
+  environment: 'sandbox' | 'production';
 }
 
 @Component({
@@ -38,11 +38,12 @@ export class LoginComponent implements OnInit {
 
   customerApi = 'https://bank.demo.cybrid.app/api/customers/';
   bearer = false;
+  environment = ['sandbox', 'production'];
   demoCredentials: DemoCredentials = {
     token: '',
     customer: '',
     isPublic: false,
-    production: false
+    environment: 'sandbox'
   };
 
   // PUBLIC CREDENTIALS FOR NO-LOGIN DEMO
@@ -79,7 +80,7 @@ export class LoginComponent implements OnInit {
         validators: [Validators.required, Validators.minLength(32)],
         nonNullable: true
       }),
-      production: new FormControl()
+      environment: new FormControl('sandbox', { nonNullable: true })
     });
 
     if (this.loginForm.valid) this.login();
@@ -199,8 +200,8 @@ export class LoginComponent implements OnInit {
       .subscribe((customer: CustomerBankModel) => {
         if (customer.guid) {
           this.demoCredentials.customer = customer.guid;
-          this.demoCredentials.production =
-            this.loginForm.controls.production.value;
+          this.demoCredentials.environment =
+            this.loginForm.controls.environment.value;
 
           publicUser
             ? (this.demoCredentials.isPublic = publicUser)

--- a/src/demo/components/login/login.component.ts
+++ b/src/demo/components/login/login.component.ts
@@ -18,12 +18,14 @@ interface LoginForm {
   clientSecret: FormControl<string>;
   bearerToken: FormControl<string>;
   customerGuid: FormControl<string>;
+  production: FormControl<boolean>;
 }
 
 export interface DemoCredentials {
   token: string;
   customer: string;
   isPublic: boolean;
+  production: boolean;
 }
 
 @Component({
@@ -39,7 +41,8 @@ export class LoginComponent implements OnInit {
   demoCredentials: DemoCredentials = {
     token: '',
     customer: '',
-    isPublic: false
+    isPublic: false,
+    production: false
   };
 
   // PUBLIC CREDENTIALS FOR NO-LOGIN DEMO
@@ -75,7 +78,8 @@ export class LoginComponent implements OnInit {
       customerGuid: new FormControl(environment.credentials.customerGuid, {
         validators: [Validators.required, Validators.minLength(32)],
         nonNullable: true
-      })
+      }),
+      production: new FormControl()
     });
 
     if (this.loginForm.valid) this.login();
@@ -195,6 +199,8 @@ export class LoginComponent implements OnInit {
       .subscribe((customer: CustomerBankModel) => {
         if (customer.guid) {
           this.demoCredentials.customer = customer.guid;
+          this.demoCredentials.production =
+            this.loginForm.controls.production.value;
 
           publicUser
             ? (this.demoCredentials.isPublic = publicUser)

--- a/src/demo/components/login/login.component.ts
+++ b/src/demo/components/login/login.component.ts
@@ -18,14 +18,14 @@ interface LoginForm {
   clientSecret: FormControl<string>;
   bearerToken: FormControl<string>;
   customerGuid: FormControl<string>;
-  environment: FormControl<'sandbox' | 'production'>;
+  environment: FormControl<'demo' | 'staging' | 'sandbox' | 'production'>;
 }
 
 export interface DemoCredentials {
   token: string;
   customer: string;
   isPublic: boolean;
-  environment: 'sandbox' | 'production';
+  environment: 'demo' | 'staging' | 'sandbox' | 'production';
 }
 
 @Component({
@@ -38,12 +38,12 @@ export class LoginComponent implements OnInit {
 
   customerApi = 'https://bank.demo.cybrid.app/api/customers/';
   bearer = false;
-  environment = ['sandbox', 'production'];
+  environment = ['demo', 'staging', 'sandbox', 'production'];
   demoCredentials: DemoCredentials = {
     token: '',
     customer: '',
     isPublic: false,
-    environment: 'sandbox'
+    environment: 'demo'
   };
 
   // PUBLIC CREDENTIALS FOR NO-LOGIN DEMO
@@ -80,7 +80,7 @@ export class LoginComponent implements OnInit {
         validators: [Validators.required, Validators.minLength(32)],
         nonNullable: true
       }),
-      environment: new FormControl('sandbox', { nonNullable: true })
+      environment: new FormControl('demo', { nonNullable: true })
     });
 
     if (this.loginForm.valid) this.login();


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [X] Feature
- [ ] Bug fix

### Linked issue
https://cybrid.atlassian.net/browse/CYB-918

### Why
We need to enable multiple environments.

### How
By adding an `environment` input to `cybrid-app`, and a `environment` control to the login form. By default the Bank client uses the base path: https://bank.demo.cybrid.app/.

<img width="478" alt="Screen Shot 2022-12-12 at 9 37 28 AM" src="https://user-images.githubusercontent.com/5817894/207072699-4190c7d6-8f14-4d2e-884a-78152e7377e4.png">