### PR TITLE
add missing library to Download/Install Chrome stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ workflows:
                 name: Install libraries
                 command: |
                   apt update -y
-                  apt install -y software-properties-common apt-transport-https wget fonts-liberation xdg-utils gnupg
+                  apt install -y software-properties-common apt-transport-https wget fonts-liberation xdg-utils gnupg libu2f-udev
             - run:
                 name: Download/Install Chrome stable
                 command: |


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [X] Bug fix

### Linked issue
- [X] Not tracked

### Why
E2E fails beacuse the latest version of Chrome stable requires library libu2f-udev.

### How
Added the missing library to the `Install libraries` step in `config.yml`