### PR TITLE
fix: add missing env paths to environment.prod.ts

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -6,7 +6,18 @@ import ci from './environment.ci.json';
 
 export const environment = {
   production: true,
-  authUrl: 'https://id.demo.cybrid.app/oauth/token',
+  idpAuthUrl: {
+    demo: 'https://id.demo.cybrid.app/oauth/token',
+    staging: 'https://id.staging.cybrid.app/oauth/token',
+    sandbox: 'https://id.sandbox.cybrid.app/oauth/token',
+    production: 'https://id.production.cybrid.app/oauth/token'
+  },
+  bankApiCustomerBasePath: {
+    demo: 'https://bank.demo.cybrid.app/api/customers/',
+    staging: 'https://bank.staging.cybrid.app/api/customers/',
+    sandbox: 'https://bank.sandbox.cybrid.app/api/customers/',
+    production: 'https://bank.production.cybrid.app/api/customers/'
+  },
   grant_type: 'client_credentials',
   credentials: ci.environment.credentials,
   scope:


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [X] Bug fix

### Linked issue
- [X] Not tracked

### Why
Production environment file for the demo app was still missing the proper Idp authentication, and Bank api paths

### How
Updated `environment.prod.ts` to match `environment.ts`