### PR TITLE
feat: update external bank account asset check to handle bank type

### DIFF
--- a/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.spec.ts
+++ b/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.spec.ts
@@ -23,7 +23,7 @@ import { BankAccountConnectComponent } from '@components';
 
 // Utility
 import { TestConstants } from '@constants';
-import { BanksService } from '@cybrid/cybrid-api-bank-angular';
+import { BankBankModel, BanksService } from '@cybrid/cybrid-api-bank-angular';
 
 describe('BankAccountConnectComponent', () => {
   let component: BankAccountConnectComponent;
@@ -168,7 +168,7 @@ describe('BankAccountConnectComponent', () => {
     expect(MockBankAccountService.createExternalBankAccount).toHaveBeenCalled();
   });
 
-  it('should handle an invalid asset', () => {
+  it('should handle an invalid asset in production banks', () => {
     const errorSpy = spyOn(component.error$, 'next');
 
     const testPlaidMetadata = {
@@ -176,12 +176,28 @@ describe('BankAccountConnectComponent', () => {
     };
 
     let bankBankModel = { ...TestConstants.BANK_BANK_MODEL };
+    bankBankModel.type = BankBankModel.TypeEnum.Production;
     bankBankModel.supported_fiat_account_assets = [];
     MockBankService.getBank.and.returnValue(of(bankBankModel));
 
     component.plaidOnSuccess('', testPlaidMetadata);
 
     expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('should always validate assets in sandbox banks', () => {
+    const testPlaidMetadata = {
+      accounts: [{ name: 'test', id: 'test', iso_currency_code: 'USD' }]
+    };
+
+    let bankBankModel = { ...TestConstants.BANK_BANK_MODEL };
+    bankBankModel.type = BankBankModel.TypeEnum.Sandbox;
+    bankBankModel.supported_fiat_account_assets = [];
+    MockBankService.getBank.and.returnValue(of(bankBankModel));
+
+    component.plaidOnSuccess('', testPlaidMetadata);
+
+    expect(MockBankAccountService.createExternalBankAccount).toHaveBeenCalled();
   });
 
   it('should handle an undefined asset', () => {

--- a/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.ts
+++ b/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.ts
@@ -22,6 +22,7 @@ import {
 
 // Services
 import {
+  BankBankModel,
   BanksService,
   CustomersService,
   PostWorkflowBankModel,
@@ -228,24 +229,16 @@ export class BankAccountConnectComponent implements OnInit {
         : metadata.accounts[0].iso_currency_code;
     const account = metadata.accounts[0];
 
-    console.log(this.config.environment);
-    console.log(
-      this.config.environment == 'demo'
-        ? 'USD'
-        : metadata.accounts[0].iso_currency_code
-    );
-    console.log(asset);
-    console.log(metadata.accounts);
-    console.log(isValidAsset(asset));
-    console.log(isOnlyAccount(metadata.accounts));
-
     if (isOnlyAccount(metadata.accounts) && isValidAsset(asset)) {
       this.configService
         .getBank$()
         .pipe(
           take(1),
           switchMap((bank) => {
-            if (bank.supported_fiat_account_assets!.includes(asset)) {
+            if (
+              bank.type == BankBankModel.TypeEnum.Sandbox ||
+              bank.supported_fiat_account_assets!.includes(asset)
+            ) {
               return this.bankAccountService.createExternalBankAccount(
                 account.name,
                 public_token,
@@ -259,8 +252,7 @@ export class BankAccountConnectComponent implements OnInit {
             this.eventService.handleEvent(
               LEVEL.ERROR,
               CODE.DATA_ERROR,
-              'There was an error creating a bank account',
-              err
+              err.message
             );
 
             this.errorService.handleError(


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [X] Feature
- [ ] Bug fix

### Linked issue
- [x] Not tracked

### Why
Adding an external bank account to a sandbox bank will fail unless the bank has been configured with the appropriate asset. We should always pass this condition for sandbox banks.

### How
Added a check for bank type while validating the external bank account asset.