### PR TITLE
chore: Add debug info for bank connect.

### DIFF
--- a/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.ts
+++ b/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.ts
@@ -230,6 +230,11 @@ export class BankAccountConnectComponent implements OnInit {
                 ? bank.supported_fiat_account_assets![0]
                 : account.iso_currency_code;
 
+            console.log(this.config.environment);
+            console.log(asset);
+            console.log(metadata.accounts);
+            console.log(bank.supported_fiat_account_assets!.includes(asset));
+
             if (bank.supported_fiat_account_assets!.includes(asset)) {
               return this.bankAccountService.createExternalBankAccount(
                 account.name,


### PR DESCRIPTION
### Type of change

- [x] Chore
- [ ] Feature
- [ ] Bug fix

### Linked issue

Support for https://cybrid.atlassian.net/browse/CYB-1016

### Why

We are failing to connect external bank accounts in Production. It is suspected it is because the `iso_currency_code` on the account coming back is not set or incorrect.

### How

Add debugging information to diagnose the problem.