### PR TITLE
fix: pre-populated trading asset from account-details

### DIFF
--- a/library/src/app/components/account/account-details/account-details.component.ts
+++ b/library/src/app/components/account/account-details/account-details.component.ts
@@ -47,7 +47,6 @@ import { TradeSummaryComponent } from '@components';
 
 // Utility
 import { Constants } from '@constants';
-import { symbolBuild } from '@utility';
 
 @Component({
   selector: 'app-account-details',
@@ -266,8 +265,7 @@ export class AccountDetailsComponent
   onTrade(): void {
     const extras: NavigationExtras = {
       queryParams: {
-        asset: JSON.stringify(this.asset),
-        symbol_pair: symbolBuild(this.asset.code, this.counterAssetCode)
+        code: this.asset.code
       }
     };
     this.routingService.handleRoute({

--- a/library/src/app/components/trade/trade.component.html
+++ b/library/src/app/components/trade/trade.component.html
@@ -30,7 +30,7 @@
                       src="{{ tradingAccount.value.asset | assetIcon }}"
                     />
                     <span class="cybrid-trigger-name">{{
-                      tradingAccount.value.name
+                      tradingAccount.value.name | truncate : 24
                     }}</span>
                   </div>
                 </mat-select-trigger>
@@ -44,7 +44,7 @@
                       alt="Crypto currency icon"
                       src="{{ account.asset | assetIcon }}"
                     />
-                    <span>{{ account.name }}</span>
+                    <span>{{ account.name | truncate : 24 }}</span>
                   </div>
                 </mat-option>
               </mat-select>

--- a/library/src/app/components/trade/trade.component.spec.ts
+++ b/library/src/app/components/trade/trade.component.spec.ts
@@ -36,7 +36,12 @@ import {
 import { Price, TradeComponent } from '@components';
 
 // Utility
-import { AssetFormatPipe, MockAssetFormatPipe, AssetIconPipe } from '@pipes';
+import {
+  AssetFormatPipe,
+  MockAssetFormatPipe,
+  AssetIconPipe,
+  TruncatePipe
+} from '@pipes';
 import { TestConstants } from '@constants';
 
 describe('TradeComponent', () => {
@@ -65,7 +70,12 @@ describe('TradeComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [TradeComponent, MockAssetFormatPipe, AssetIconPipe],
+      declarations: [
+        TradeComponent,
+        MockAssetFormatPipe,
+        AssetIconPipe,
+        TruncatePipe
+      ],
       imports: [
         BrowserAnimationsModule,
         HttpClientTestingModule,

--- a/library/src/shared/pipes/truncate/truncate.pipe.spec.ts
+++ b/library/src/shared/pipes/truncate/truncate.pipe.spec.ts
@@ -12,7 +12,7 @@ describe('AssetPipe', () => {
     expect(test).toEqual('test');
   });
 
-  it('should truncate the value by the number of characters set if the value.length is greater', () => {
+  it('should truncateString the value by the number of characters set if the value.length is greater', () => {
     const pipe = new TruncatePipe();
     const test = pipe.transform('test', 2);
     expect(test).toEqual('te...');

--- a/library/src/shared/pipes/truncate/tuncate.pipe.ts
+++ b/library/src/shared/pipes/truncate/tuncate.pipe.ts
@@ -6,12 +6,12 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class TruncatePipe implements PipeTransform {
   constructor() {}
 
-  transform(value: string, char?: number) {
+  transform(value: string | undefined, char?: number) {
     if (char === undefined) {
       return value;
     }
 
-    if (value.length > char) {
+    if (value && value.length > char) {
       return value.substring(0, char) + '...';
     } else {
       return value;


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [X] Bug fix

### Linked issue
https://cybrid.atlassian.net/browse/CYB-1057
https://cybrid.atlassian.net/browse/CYB-1056

### Why
Navigating via the trade button in account details doesn't preserve the selected asset.

### How
By ensuring the correct query param is passed to the trade component to avoid a default asset being selected.

Also included is a truncation fix for extra long trading account names in the trade-component.