### PR TITLE
fix: flaky e2e bank-connect Plaid SDK network error test

### DIFF
--- a/cypress/e2e/bank-account-connect.cy.ts
+++ b/cypress/e2e/bank-account-connect.cy.ts
@@ -1,5 +1,6 @@
 import * as translations from 'library/src/shared/i18n/en';
 import { Plaid } from '../support/plaid';
+import { TestConstants } from '@constants';
 
 const text = translations.default;
 
@@ -44,6 +45,16 @@ describe('bank-account-connect test', () => {
   });
 
   it('should handle error loading Plaid script', () => {
+    // Mock POST Workflow
+    cy.intercept('POST', '/api/workflows', (req) => {
+      req.reply(TestConstants.WORKFLOW_BANK_MODEL);
+    }).as('postWorkflow');
+
+    // Mock GET Workflow
+    cy.intercept('GET', '/api/workflows/*', (req) => {
+      req.reply(TestConstants.WORKFLOW_BANK_MODEL_WITH_DETAILS);
+    }).as('getWorkflow');
+
     // Force loading Plaid script to error
     cy.intercept('GET', '/link/v2/stable/*', (req) => {
       req.reply({ forceNetworkError: true });
@@ -56,7 +67,7 @@ describe('bank-account-connect test', () => {
     });
   });
 
-  it('should allow resume on Plaid exit', () => {
+  xit('should allow resume on Plaid exit', () => {
     // Indicates Plaid app is open
     cy.intercept('POST', '/link/heartbeat').as('heartbeat');
 
@@ -74,7 +85,7 @@ describe('bank-account-connect test', () => {
     app().get('app-bank-account-connect').find('app-loading').should('exist');
   });
 
-  it('should cancel on Plaid exit', () => {
+  xit('should cancel on Plaid exit', () => {
     // Indicates Plaid app is open
     cy.intercept('POST', '/link/heartbeat').as('heartbeat');
 
@@ -92,7 +103,7 @@ describe('bank-account-connect test', () => {
     app().should('not.exist');
   });
 
-  it('should handle success from Plaid with defined iso_currency_code', () => {
+  xit('should handle success from Plaid with defined iso_currency_code', () => {
     // Indicates Plaid app is open
     cy.intercept('POST', '/link/heartbeat').as('heartbeat');
 
@@ -121,7 +132,7 @@ describe('bank-account-connect test', () => {
     app().should('not.exist');
   });
 
-  it('should open confirm dialog on success from Plaid with undefined iso_currency_code', () => {
+  xit('should open confirm dialog on success from Plaid with undefined iso_currency_code', () => {
     // Indicates Plaid app is open
     cy.intercept('POST', '/link/heartbeat').as('heartbeat');
 
@@ -157,7 +168,7 @@ describe('bank-account-connect test', () => {
     cy.get('mat-dialog-container').contains(text.cancel).click();
   });
 
-  it('should add external bank account on confirm in the confirm dialog', () => {
+  xit('should add external bank account on confirm in the confirm dialog', () => {
     // Indicates Plaid app is open
     cy.intercept('POST', '/link/heartbeat').as('heartbeat');
 

--- a/cypress/e2e/bank-account-connect.cy.ts
+++ b/cypress/e2e/bank-account-connect.cy.ts
@@ -67,7 +67,7 @@ describe('bank-account-connect test', () => {
     });
   });
 
-  xit('should allow resume on Plaid exit', () => {
+  it('should allow resume on Plaid exit', () => {
     // Indicates Plaid app is open
     cy.intercept('POST', '/link/heartbeat').as('heartbeat');
 
@@ -85,7 +85,7 @@ describe('bank-account-connect test', () => {
     app().get('app-bank-account-connect').find('app-loading').should('exist');
   });
 
-  xit('should cancel on Plaid exit', () => {
+  it('should cancel on Plaid exit', () => {
     // Indicates Plaid app is open
     cy.intercept('POST', '/link/heartbeat').as('heartbeat');
 
@@ -103,7 +103,7 @@ describe('bank-account-connect test', () => {
     app().should('not.exist');
   });
 
-  xit('should handle success from Plaid with defined iso_currency_code', () => {
+  it('should handle success from Plaid with defined iso_currency_code', () => {
     // Indicates Plaid app is open
     cy.intercept('POST', '/link/heartbeat').as('heartbeat');
 
@@ -132,7 +132,7 @@ describe('bank-account-connect test', () => {
     app().should('not.exist');
   });
 
-  xit('should open confirm dialog on success from Plaid with undefined iso_currency_code', () => {
+  it('should open confirm dialog on success from Plaid with undefined iso_currency_code', () => {
     // Indicates Plaid app is open
     cy.intercept('POST', '/link/heartbeat').as('heartbeat');
 
@@ -168,7 +168,7 @@ describe('bank-account-connect test', () => {
     cy.get('mat-dialog-container').contains(text.cancel).click();
   });
 
-  xit('should add external bank account on confirm in the confirm dialog', () => {
+  it('should add external bank account on confirm in the confirm dialog', () => {
     // Indicates Plaid app is open
     cy.intercept('POST', '/link/heartbeat').as('heartbeat');
 


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [X] Bug fix

### Linked issue

- [X] Not tracked

### Why
Cypress sometimes times out waiting for `POST /api/workflows` in the Plaid SDK forced network error test.

### How
Added mock interceptors for both `POST /api/workflows` and `GET /api/workflows/*`.