### PR TITLE
feat: add local environment paths and login selection

### DIFF
--- a/library/src/environments/environment.ts
+++ b/library/src/environments/environment.ts
@@ -5,6 +5,7 @@
 export const environment = {
   production: false,
   demoBankApiBasePath: 'https://bank.demo.cybrid.app',
+  localBankApiBasePath: 'http://api-platform-bank.local.cybrid.com:3002',
   stagingBankApiBasePath: 'https://bank.staging.cybrid.app',
   sandboxBankApiBasePath: 'https://bank.sandbox.cybrid.app',
   productionBankApiBasePath: 'https://bank.production.cybrid.app'

--- a/library/src/shared/services/config/config.service.spec.ts
+++ b/library/src/shared/services/config/config.service.spec.ts
@@ -141,8 +141,16 @@ describe('ConfigService', () => {
       environment.demoBankApiBasePath
     );
 
-    // 'staging'
+    // 'local'
     let testConfig = { ...TestConstants.CONFIG };
+    testConfig.environment = 'local';
+
+    service.setEnvironment(testConfig);
+    expect(service['configuration'].basePath).toEqual(
+      environment.localBankApiBasePath
+    );
+
+    // 'staging'
     testConfig.environment = 'staging';
 
     service.setEnvironment(testConfig);

--- a/library/src/shared/services/config/config.service.ts
+++ b/library/src/shared/services/config/config.service.ts
@@ -37,7 +37,7 @@ export interface ComponentConfig {
   routing: boolean;
   customer: string; // Temporary solution until the JWT embeds a customer GUID
   fiat: string;
-  environment: 'demo' | 'staging' | 'sandbox' | 'production';
+  environment: 'demo' | 'local' | 'staging' | 'sandbox' | 'production';
 }
 
 @Injectable({
@@ -137,6 +137,9 @@ export class ConfigService implements OnDestroy {
     switch (config.environment) {
       case 'demo':
         this.configuration.basePath = environment.demoBankApiBasePath;
+        return true;
+      case 'local':
+        this.configuration.basePath = environment.localBankApiBasePath;
         return true;
       case 'staging':
         this.configuration.basePath = environment.stagingBankApiBasePath;

--- a/src/demo/components/login/login.component.ts
+++ b/src/demo/components/login/login.component.ts
@@ -25,7 +25,7 @@ export interface DemoCredentials {
   token: string;
   customer: string;
   isPublic: boolean;
-  environment: 'demo' | 'staging' | 'sandbox' | 'production';
+  environment: 'demo' | 'local' | 'staging' | 'sandbox' | 'production';
 }
 
 @Component({
@@ -37,7 +37,7 @@ export class LoginComponent implements OnInit {
   @Output() credentials = new EventEmitter<DemoCredentials>();
 
   bearer = false;
-  environment = ['demo', 'staging', 'sandbox', 'production'];
+  environment = ['demo', 'local', 'staging', 'sandbox', 'production'];
   demoCredentials: DemoCredentials = {
     token: '',
     customer: '',
@@ -89,6 +89,9 @@ export class LoginComponent implements OnInit {
     switch (env) {
       case 'demo': {
         return environment.bankApiCustomerBasePath.demo;
+      }
+      case 'local': {
+        return environment.bankApiCustomerBasePath.local;
       }
       case 'staging': {
         return environment.bankApiCustomerBasePath.staging;

--- a/src/demo/services/demo-config/demo-config.service.ts
+++ b/src/demo/services/demo-config/demo-config.service.ts
@@ -21,6 +21,9 @@ export class DemoConfigService {
       case 'demo': {
         return environment.idpAuthUrl.demo;
       }
+      case 'local': {
+        return environment.idpAuthUrl.local;
+      }
       case 'staging': {
         return environment.idpAuthUrl.staging;
       }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -10,12 +10,14 @@ export const environment = {
   production: false,
   idpAuthUrl: {
     demo: 'https://id.demo.cybrid.app/oauth/token',
+    local: 'http://api-idp.local.cybrid.com:3000/oauth/token',
     staging: 'https://id.staging.cybrid.app/oauth/token',
     sandbox: 'https://id.sandbox.cybrid.app/oauth/token',
     production: 'https://id.production.cybrid.app/oauth/token'
   },
   bankApiCustomerBasePath: {
     demo: 'https://bank.demo.cybrid.app/api/customers/',
+    local: 'http://api-platform-bank.local.cybrid.com:3002/api/customers/',
     staging: 'https://bank.staging.cybrid.app/api/customers/',
     sandbox: 'https://bank.sandbox.cybrid.app/api/customers/',
     production: 'https://bank.production.cybrid.app/api/customers/'


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [X] Feature
- [ ] Bug fix

### Linked issue

- [X] Not tracked

### Why
For debugging purposes we want to be able to run the Demo application against a local instance of the Cybrid platform.

### How
By adding the necessary local urls and an environment selection to the login component.