### PR TITLE
fix: account-details total defaulting to BTC

### DIFF
--- a/library/src/shared/constants/test.constants.ts
+++ b/library/src/shared/constants/test.constants.ts
@@ -296,7 +296,7 @@ export class TestConstants {
       url: 'https://images.cybrid.xyz/sdk/assets/svg/color/usd.svg'
     },
     price: {
-      symbol: 'BTC',
+      symbol: 'BTC-USD',
       buy_price: '2129800',
       sell_price: '2129700',
       buy_price_last_updated_at: '2022-07-27T13:28:13.322Z',

--- a/library/src/shared/services/account/account.service.ts
+++ b/library/src/shared/services/account/account.service.ts
@@ -31,7 +31,7 @@ import {
 } from '@services';
 
 // Utility
-import { filterPrices, symbolSplit } from '@utility';
+import { filterPrices, symbolBuild, symbolSplit } from '@utility';
 import { AssetPipe } from '@pipes';
 
 export interface Account {
@@ -149,11 +149,16 @@ export class AccountService implements OnDestroy {
           pricesModel: SymbolPriceBankModel[]
         ] = combined;
 
-        const priceModel = pricesModel.find((price) => {
-          return (price.symbol = accountModel.asset);
-        });
         const assetModel = this.assetService.getAsset(accountModel.asset!);
         const counterAssetModel = this.assetService.getAsset(counterAsset);
+        const symbol = symbolBuild(
+          accountModel.asset!,
+          counterAssetModel.code!
+        );
+
+        const priceModel = pricesModel.find((price) => {
+          return price.symbol == symbol;
+        });
 
         const accountValue = this.getAccountValue(
           {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8637,9 +8637,9 @@
       "dev": true
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "node_modules/http-deceiver": {
@@ -21582,9 +21582,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "http-deceiver": {


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [X] Bug fix

### Linked issue
- [X] Not tracked

### Why
The account-details component was defaulting the asset price to `BTC` due to an assignment error.

### How
Changed the assignment to equate values instead and utilized the `symbol-build` function to find the current asset/counter-asset symbol price.