### PR TITLE
feat: add bank account-details and disconnect

### DIFF
--- a/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.ts
+++ b/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.ts
@@ -24,6 +24,7 @@ import {
 import {
   BankBankModel,
   CustomersService,
+  ExternalBankAccountBankModel,
   PostWorkflowBankModel,
   WorkflowsService,
   WorkflowWithDetailsBankModel
@@ -140,13 +141,13 @@ export class BankAccountConnectComponent implements OnInit {
       .pipe(
         take(1),
         switchMap((params) => {
-          const externalAccountGuid = params['externalAccountGuid'];
-          this.params = externalAccountGuid;
+          const externalBankAccountGuid = params['externalBankAccountGuid'];
+          this.params = externalBankAccountGuid;
 
-          return externalAccountGuid
+          return externalBankAccountGuid
             ? this.createWorkflow(
                 PostWorkflowBankModel.KindEnum.Update,
-                externalAccountGuid
+                externalBankAccountGuid
               )
             : this.createWorkflow(PostWorkflowBankModel.KindEnum.Create);
         }),

--- a/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.html
+++ b/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.html
@@ -33,7 +33,7 @@
         account.state === 'failed'
       "
       id="disconnect"
-      color="warn"
+      color="primary"
       mat-flat-button
       (click)="onDisconnect(account)"
     >

--- a/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.html
+++ b/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.html
@@ -23,7 +23,7 @@
     <mat-divider></mat-divider>
   </mat-dialog-content>
   <mat-dialog-actions align="end">
-    <button id="done" mat-stroked-button [mat-dialog-close]="false">
+    <button id="cancel" mat-stroked-button [mat-dialog-close]="false">
       {{ 'cancel' | translate }}
     </button>
     <button

--- a/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.html
+++ b/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.html
@@ -1,29 +1,29 @@
 <ng-container *ngIf="(isRecoverable$ | async) !== false; else error">
-  <h2 mat-dialog-title>Account Details</h2>
+  <h2 mat-dialog-title>{{ 'bankAccountList.details.title' | translate }}</h2>
   <mat-dialog-content>
     <div class="cybrid-list-item">
-      <span>Name</span>
+      <span>{{ 'bankAccountList.details.name' | translate }}</span>
       <span>{{ account.name }}</span>
     </div>
     <mat-divider></mat-divider>
     <div class="cybrid-list-item">
-      <span>Asset</span>
+      <span>{{ 'bankAccountList.details.asset' | translate }}</span>
       <span>{{ account.asset }}</span>
     </div>
     <mat-divider></mat-divider>
     <div class="cybrid-list-item">
-      <span>Number</span>
+      <span>{{ 'bankAccountList.details.number' | translate }}</span>
       <span>{{ '(***' + account.plaid_account_mask + ')' }}</span>
     </div>
     <mat-divider></mat-divider>
     <div class="cybrid-list-item">
-      <span>Status</span>
+      <span>{{ 'bankAccountList.details.status' | translate }}</span>
       <span>{{ 'bankAccountList.state.' + account.state | translate }}</span>
     </div>
     <mat-divider></mat-divider>
   </mat-dialog-content>
   <mat-dialog-actions align="end">
-    <button id="done" mat-stroked-button [mat-dialog-close]="true">
+    <button id="done" mat-stroked-button [mat-dialog-close]="false">
       {{ 'cancel' | translate }}
     </button>
     <button
@@ -37,7 +37,7 @@
       mat-flat-button
       (click)="onDisconnect(account)"
     >
-      DISCONNECT
+      {{ 'disconnect' | translate }}
     </button>
     <button
       *ngIf="account.state === 'refresh_required'"
@@ -46,7 +46,7 @@
       mat-flat-button
       (click)="onReconnect(account)"
     >
-      RECONNECT
+      {{ 'reconnect' | translate }}
     </button>
   </mat-dialog-actions>
 </ng-container>

--- a/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.html
+++ b/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.html
@@ -1,0 +1,61 @@
+<ng-container *ngIf="(isRecoverable$ | async) !== false; else error">
+  <h2 mat-dialog-title>Account Details</h2>
+  <mat-dialog-content>
+    <div class="cybrid-list-item">
+      <span>Name</span>
+      <span>{{ account.name }}</span>
+    </div>
+    <mat-divider></mat-divider>
+    <div class="cybrid-list-item">
+      <span>Asset</span>
+      <span>{{ account.asset }}</span>
+    </div>
+    <mat-divider></mat-divider>
+    <div class="cybrid-list-item">
+      <span>Number</span>
+      <span>{{ '(***' + account.plaid_account_mask + ')' }}</span>
+    </div>
+    <mat-divider></mat-divider>
+    <div class="cybrid-list-item">
+      <span>Status</span>
+      <span>{{ 'bankAccountList.state.' + account.state | translate }}</span>
+    </div>
+    <mat-divider></mat-divider>
+  </mat-dialog-content>
+  <mat-dialog-actions align="end">
+    <button id="done" mat-stroked-button [mat-dialog-close]="true">
+      {{ 'cancel' | translate }}
+    </button>
+    <button
+      *ngIf="
+        account.state === 'completed' ||
+        account.state === 'refresh_required' ||
+        account.state === 'failed'
+      "
+      id="disconnect"
+      color="warn"
+      mat-flat-button
+      (click)="onDisconnect(account)"
+    >
+      DISCONNECT
+    </button>
+    <button
+      *ngIf="account.state === 'refresh_required'"
+      id="reconnect"
+      color="primary"
+      mat-flat-button
+      (click)="onReconnect(account)"
+    >
+      RECONNECT
+    </button>
+  </mat-dialog-actions>
+</ng-container>
+<ng-template #error>
+  <mat-card>
+    <mat-card-content>
+      <div class="fatal">
+        <p>{{ 'fatal' | translate }}</p>
+      </div>
+    </mat-card-content>
+  </mat-card>
+</ng-template>

--- a/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.scss
+++ b/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.scss
@@ -1,0 +1,26 @@
+.cybrid-list-item {
+  height: 3rem;
+  display: flex;
+  flex-grow: 1;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+
+  div {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+}
+
+//@media screen and (max-width: 599px) {
+//  mat-dialog-actions {
+//    flex-direction: column-reverse;
+//    align-items: stretch;
+//    gap: 0.5rem;
+//  }
+//
+//  .mat-dialog-actions .mat-button-base + .mat-button-base {
+//    margin: 0;
+//  }
+//}

--- a/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.scss
+++ b/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.scss
@@ -12,15 +12,3 @@
     gap: 0.5rem;
   }
 }
-
-//@media screen and (max-width: 599px) {
-//  mat-dialog-actions {
-//    flex-direction: column-reverse;
-//    align-items: stretch;
-//    gap: 0.5rem;
-//  }
-//
-//  .mat-dialog-actions .mat-button-base + .mat-button-base {
-//    margin: 0;
-//  }
-//}

--- a/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.spec.ts
+++ b/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.spec.ts
@@ -1,0 +1,53 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+// Components
+import { BankAccountDetailsComponent } from '@components';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { SharedModule } from '../../../../shared/modules/shared.module';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { HttpLoaderFactory } from '../../../modules/library.module';
+import { HttpClient } from '@angular/common/http';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { TruncatePipe } from '@pipes';
+
+describe('BankAccountDetailsComponent', () => {
+  let component: BankAccountDetailsComponent;
+  let fixture: ComponentFixture<BankAccountDetailsComponent>;
+
+  let MockDialogRef = jasmine.createSpyObj('MatDialogRef', ['open', 'close']);
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [BankAccountDetailsComponent, TruncatePipe],
+      imports: [
+        BrowserAnimationsModule,
+        HttpClientTestingModule,
+        SharedModule,
+        RouterTestingModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useFactory: HttpLoaderFactory,
+            deps: [HttpClient]
+          }
+        })
+      ],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialogRef, useValue: MockDialogRef }
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BankAccountDetailsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.spec.ts
+++ b/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.spec.ts
@@ -1,7 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
-// Components
-import { BankAccountDetailsComponent } from '@components';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { SharedModule } from '../../../../shared/modules/shared.module';
@@ -11,12 +8,26 @@ import { HttpLoaderFactory } from '../../../modules/library.module';
 import { HttpClient } from '@angular/common/http';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+// Services
+import { BankAccountService, RoutingService } from '@services';
+
+// Components
+import { BankAccountDetailsComponent } from '@components';
+
+// Utility
 import { TruncatePipe } from '@pipes';
 
 describe('BankAccountDetailsComponent', () => {
   let component: BankAccountDetailsComponent;
   let fixture: ComponentFixture<BankAccountDetailsComponent>;
 
+  let MockBankAccountService = jasmine.createSpyObj('BankAccountService', [
+    'deleteExternalBankAccount'
+  ]);
+  let MockRoutingService = jasmine.createSpyObj('RoutingService', [
+    'handleRoute'
+  ]);
   let MockDialogRef = jasmine.createSpyObj('MatDialogRef', ['open', 'close']);
 
   beforeEach(async () => {
@@ -36,11 +47,15 @@ describe('BankAccountDetailsComponent', () => {
         })
       ],
       providers: [
+        { provide: BankAccountService, useValue: MockBankAccountService },
+        { provide: RoutingService, useValue: MockRoutingService },
         { provide: MAT_DIALOG_DATA, useValue: {} },
         { provide: MatDialogRef, useValue: MockDialogRef }
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
+    MockBankAccountService = TestBed.inject(BankAccountService);
+    MockRoutingService = TestBed.inject(RoutingService);
 
     fixture = TestBed.createComponent(BankAccountDetailsComponent);
     component = fixture.componentInstance;

--- a/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.spec.ts
+++ b/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.spec.ts
@@ -3,11 +3,21 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { SharedModule } from '../../../../shared/modules/shared.module';
 import { RouterTestingModule } from '@angular/router/testing';
-import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import {
+  TranslateLoader,
+  TranslateModule,
+  TranslatePipe
+} from '@ngx-translate/core';
 import { HttpLoaderFactory } from '../../../modules/library.module';
 import { HttpClient } from '@angular/common/http';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import {
+  MAT_DIALOG_DATA,
+  MatDialog,
+  MatDialogRef
+} from '@angular/material/dialog';
+
+import { of } from 'rxjs';
 
 // Services
 import { BankAccountService, RoutingService } from '@services';
@@ -17,6 +27,8 @@ import { BankAccountDetailsComponent } from '@components';
 
 // Utility
 import { TruncatePipe } from '@pipes';
+import { TestConstants } from '@constants';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 describe('BankAccountDetailsComponent', () => {
   let component: BankAccountDetailsComponent;
@@ -28,7 +40,9 @@ describe('BankAccountDetailsComponent', () => {
   let MockRoutingService = jasmine.createSpyObj('RoutingService', [
     'handleRoute'
   ]);
-  let MockDialogRef = jasmine.createSpyObj('MatDialogRef', ['open', 'close']);
+  let MockDialog = jasmine.createSpyObj('Dialog', ['open']);
+  let MockDialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
+  let MockSnackbar = jasmine.createSpyObj('MatSnackBar', ['open']);
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -49,20 +63,88 @@ describe('BankAccountDetailsComponent', () => {
       providers: [
         { provide: BankAccountService, useValue: MockBankAccountService },
         { provide: RoutingService, useValue: MockRoutingService },
-        { provide: MAT_DIALOG_DATA, useValue: {} },
-        { provide: MatDialogRef, useValue: MockDialogRef }
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL
+        },
+        { provide: MatDialog, useValue: MockDialog },
+        { provide: MatDialogRef, useValue: MockDialogRef },
+        { provide: MatSnackBar, useValue: MockSnackbar },
+        TranslatePipe
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
     MockBankAccountService = TestBed.inject(BankAccountService);
+    MockBankAccountService.deleteExternalBankAccount.and.returnValue(
+      of(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL)
+    );
     MockRoutingService = TestBed.inject(RoutingService);
+    MockDialog = TestBed.inject(MatDialog);
+    MockDialog.open.and.returnValue({ afterClosed: () => of(true) });
 
     fixture = TestBed.createComponent(BankAccountDetailsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+
+    component.data = TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL;
+  });
+
+  afterEach(() => {
+    MockBankAccountService.deleteExternalBankAccount.calls.reset();
+    MockDialog.open.calls.reset();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should validate an external bank account', () => {
+    expect(component.validateExternalBankAccount(true)).toBeFalse();
+    expect(
+      component.validateExternalBankAccount(
+        TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL
+      )
+    ).toBeTrue();
+  });
+
+  it('should open the bank-account-disconnect dialog', () => {
+    component.onDisconnect(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL);
+    expect(MockDialog.open).toHaveBeenCalled();
+  });
+
+  it('should disconnect a bank account on confirmation', () => {
+    component.onDisconnect(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL);
+    expect(MockBankAccountService.deleteExternalBankAccount).toHaveBeenCalled();
+  });
+
+  it('should do nothing if disconnection is cancelled', () => {
+    // Cancel disconnection dialog
+    MockDialog.open.and.returnValue({
+      afterClosed: () => of(false)
+    });
+
+    component.onDisconnect(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL);
+    expect(
+      MockBankAccountService.deleteExternalBankAccount
+    ).toHaveBeenCalledTimes(0);
+  });
+
+  it('should open a snackbar message on successful disconnection', () => {
+    component.onDisconnect(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL);
+    expect(MockSnackbar.open).toHaveBeenCalled();
+  });
+
+  it('should open a snackbar on error disconnecting', () => {
+    MockBankAccountService.deleteExternalBankAccount.and.returnValue(
+      of(new Error(''))
+    );
+    component.onDisconnect(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL);
+    expect(MockSnackbar.open).toHaveBeenCalled();
+  });
+
+  it('should call the routing service on reconnect', () => {
+    component.onReconnect(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL);
+    expect(MockRoutingService.handleRoute).toHaveBeenCalled();
+    expect(MockDialogRef.close).toHaveBeenCalled();
   });
 });

--- a/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.ts
+++ b/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.ts
@@ -4,20 +4,9 @@ import {
   MatDialog,
   MatDialogRef
 } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
-import {
-  BehaviorSubject,
-  catchError,
-  EMPTY,
-  map,
-  NEVER,
-  Observable,
-  of,
-  switchMap,
-  take,
-  takeUntil,
-  tap
-} from 'rxjs';
+import { BehaviorSubject, map, of, switchMap, take } from 'rxjs';
 
 // Services
 import {
@@ -32,7 +21,6 @@ import { BankAccountDisconnectComponent } from '@components';
 
 // Models
 import { ExternalBankAccountBankModel } from '@cybrid/cybrid-api-bank-angular/model/externalBankAccount';
-import { MatSnackBar } from '@angular/material/snack-bar';
 
 interface ExternalBankAccountModel extends ExternalBankAccountBankModel {}
 
@@ -76,13 +64,12 @@ export class BankAccountDetailsComponent {
             snackBar.open(message + account.name, 'OK', { duration: 5000 });
           }
 
-          // Runtime check for model/error
           if (Object.keys(res).includes('guid')) {
             this.dialogRef.close(true);
-            openSnackbar(this.snackBar, 'Disconnected bank account: ');
+            openSnackbar(this.snackBar, 'Disconnected ');
           } else {
             this.dialogRef.close(false);
-            openSnackbar(this.snackBar, 'Error disconnecting bank account: ');
+            openSnackbar(this.snackBar, 'Error disconnecting ');
           }
         })
       )

--- a/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.ts
+++ b/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.ts
@@ -79,10 +79,10 @@ export class BankAccountDetailsComponent {
           // Runtime check for model/error
           if (Object.keys(res).includes('guid')) {
             this.dialogRef.close(true);
-            openSnackbar(this.snackBar, 'Disconnecting: ');
+            openSnackbar(this.snackBar, 'Disconnected bank account: ');
           } else {
             this.dialogRef.close(false);
-            openSnackbar(this.snackBar, 'Error disconnecting: ');
+            openSnackbar(this.snackBar, 'Error disconnecting bank account: ');
           }
         })
       )

--- a/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.ts
+++ b/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.ts
@@ -1,0 +1,106 @@
+import { Component, Inject } from '@angular/core';
+import {
+  MAT_DIALOG_DATA,
+  MatDialog,
+  MatDialogRef
+} from '@angular/material/dialog';
+
+import {
+  BehaviorSubject,
+  catchError,
+  EMPTY,
+  map,
+  NEVER,
+  Observable,
+  of,
+  switchMap,
+  take,
+  takeUntil,
+  tap
+} from 'rxjs';
+
+// Services
+import {
+  BankAccountService,
+  ConfigService,
+  RoutingData,
+  RoutingService
+} from '@services';
+
+// Components
+import { BankAccountDisconnectComponent } from '@components';
+
+// Models
+import { ExternalBankAccountBankModel } from '@cybrid/cybrid-api-bank-angular/model/externalBankAccount';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+interface ExternalBankAccountModel extends ExternalBankAccountBankModel {}
+
+@Component({
+  selector: 'app-bank-account-details',
+  templateUrl: './bank-account-details.component.html',
+  styleUrls: ['./bank-account-details.component.scss']
+})
+export class BankAccountDetailsComponent {
+  account!: ExternalBankAccountBankModel;
+  isRecoverable$ = new BehaviorSubject(true);
+
+  constructor(
+    public configService: ConfigService,
+    @Inject(MAT_DIALOG_DATA) public data: ExternalBankAccountModel,
+    public dialogRef: MatDialogRef<BankAccountDetailsComponent>,
+    public dialog: MatDialog,
+    private router: RoutingService,
+    private bankAccountsService: BankAccountService,
+    private snackBar: MatSnackBar
+  ) {
+    this.account = data;
+  }
+
+  onDisconnect(account: ExternalBankAccountModel): void {
+    const dialog = this.dialog.open(BankAccountDisconnectComponent, {
+      data: account.name
+    });
+
+    dialog
+      .afterClosed()
+      .pipe(
+        take(1),
+        switchMap((res: boolean) => {
+          return res
+            ? this.bankAccountsService.deleteExternalBankAccount(account.guid!)
+            : of(res);
+        }),
+        map((res: boolean | ExternalBankAccountBankModel) => {
+          function openSnackbar(snackBar: MatSnackBar, message: string) {
+            snackBar.open(message + account.name, 'OK', { duration: 5000 });
+          }
+
+          // Runtime check for model/error
+          if (Object.keys(res).includes('guid')) {
+            this.dialogRef.close(true);
+            openSnackbar(this.snackBar, 'Disconnecting: ');
+          } else {
+            this.dialogRef.close(false);
+            openSnackbar(this.snackBar, 'Error disconnecting: ');
+          }
+        })
+      )
+      .subscribe();
+  }
+
+  onReconnect(externalBankAccount: ExternalBankAccountModel): void {
+    const routingData: RoutingData = {
+      origin: 'bank-account-list',
+      route: 'bank-account-connect',
+      extras: {
+        queryParams: {
+          externalBankAccountGuid: externalBankAccount.guid
+        }
+      }
+    };
+
+    this.dialogRef.close();
+    this.router.handleRoute(routingData);
+  }
+}

--- a/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.ts
+++ b/library/src/app/components/bank-account-management/bank-account-details/bank-account-details.component.ts
@@ -9,12 +9,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { BehaviorSubject, map, of, switchMap, take } from 'rxjs';
 
 // Services
-import {
-  BankAccountService,
-  ConfigService,
-  RoutingData,
-  RoutingService
-} from '@services';
+import { BankAccountService, RoutingData, RoutingService } from '@services';
 
 // Components
 import { BankAccountDisconnectComponent } from '@components';
@@ -34,12 +29,11 @@ export class BankAccountDetailsComponent {
   isRecoverable$ = new BehaviorSubject(true);
 
   constructor(
-    public configService: ConfigService,
     @Inject(MAT_DIALOG_DATA) public data: ExternalBankAccountModel,
     public dialogRef: MatDialogRef<BankAccountDetailsComponent>,
     public dialog: MatDialog,
     private router: RoutingService,
-    private bankAccountsService: BankAccountService,
+    private bankAccountService: BankAccountService,
     private snackBar: MatSnackBar
   ) {
     this.account = data;
@@ -56,7 +50,7 @@ export class BankAccountDetailsComponent {
         take(1),
         switchMap((res: boolean) => {
           return res
-            ? this.bankAccountsService.deleteExternalBankAccount(account.guid!)
+            ? this.bankAccountService.deleteExternalBankAccount(account.guid!)
             : of(res);
         }),
         map((res: boolean | ExternalBankAccountBankModel) => {

--- a/library/src/app/components/bank-account-management/bank-account-disconnect/bank-account-disconnect.component.html
+++ b/library/src/app/components/bank-account-management/bank-account-disconnect/bank-account-disconnect.component.html
@@ -13,10 +13,10 @@
   </p>
 </mat-dialog-content>
 <mat-dialog-actions align="end">
-  <button id="done" mat-stroked-button [mat-dialog-close]="false">
+  <button id="cancel" mat-stroked-button [mat-dialog-close]="false">
     {{ 'cancel' | translate }}
   </button>
-  <button id="confirm" mat-flat-button color="warn" [mat-dialog-close]="true">
+  <button id="disconnect" mat-flat-button color="warn" [mat-dialog-close]="true">
     {{ 'disconnect' | translate }}
   </button>
 </mat-dialog-actions>

--- a/library/src/app/components/bank-account-management/bank-account-disconnect/bank-account-disconnect.component.html
+++ b/library/src/app/components/bank-account-management/bank-account-disconnect/bank-account-disconnect.component.html
@@ -1,0 +1,15 @@
+<h2 mat-dialog-title>Confirm Disconnect</h2>
+<mat-dialog-content>
+  <p>Please confirm removal of {{ accountName }}.</p>
+  <p class="mat-body-strong">
+    Deposits will no longer be possible from this account.
+  </p>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button id="done" mat-stroked-button [mat-dialog-close]="false">
+    {{ 'cancel' | translate }}
+  </button>
+  <button id="confirm" mat-flat-button color="warn" [mat-dialog-close]="true">
+    {{ 'DISCONNECT' }}
+  </button>
+</mat-dialog-actions>

--- a/library/src/app/components/bank-account-management/bank-account-disconnect/bank-account-disconnect.component.html
+++ b/library/src/app/components/bank-account-management/bank-account-disconnect/bank-account-disconnect.component.html
@@ -6,10 +6,10 @@
   </p>
 </mat-dialog-content>
 <mat-dialog-actions align="end">
-  <button id="done" mat-stroked-button [mat-dialog-close]="false">
+  <button id="done" mat-stroked-button [mat-dialog-close]="">
     {{ 'cancel' | translate }}
   </button>
   <button id="confirm" mat-flat-button color="warn" [mat-dialog-close]="true">
-    {{ 'DISCONNECT' }}
+    {{ 'disconnect' | translate }}
   </button>
 </mat-dialog-actions>

--- a/library/src/app/components/bank-account-management/bank-account-disconnect/bank-account-disconnect.component.html
+++ b/library/src/app/components/bank-account-management/bank-account-disconnect/bank-account-disconnect.component.html
@@ -17,6 +17,6 @@
     {{ 'cancel' | translate }}
   </button>
   <button id="disconnect" mat-flat-button color="warn" [mat-dialog-close]="true">
-    {{ 'disconnect' | translate }}
+    {{ 'confirm' | translate }}
   </button>
 </mat-dialog-actions>

--- a/library/src/app/components/bank-account-management/bank-account-disconnect/bank-account-disconnect.component.html
+++ b/library/src/app/components/bank-account-management/bank-account-disconnect/bank-account-disconnect.component.html
@@ -1,12 +1,19 @@
-<h2 mat-dialog-title>Confirm Disconnect</h2>
+<h2 mat-dialog-title>{{ 'bankAccountList.disconnect.title' | translate }}</h2>
 <mat-dialog-content>
-  <p>Please confirm removal of {{ accountName }}.</p>
+  <p>
+    {{
+      ('bankAccountList.disconnect.confirm' | translate) +
+        ' ' +
+        accountName +
+        '.'
+    }}
+  </p>
   <p class="mat-body-strong">
-    Deposits will no longer be possible from this account.
+    {{ ('bankAccountList.disconnect.warning' | translate) + '.' }}
   </p>
 </mat-dialog-content>
 <mat-dialog-actions align="end">
-  <button id="done" mat-stroked-button [mat-dialog-close]="">
+  <button id="done" mat-stroked-button [mat-dialog-close]="false">
     {{ 'cancel' | translate }}
   </button>
   <button id="confirm" mat-flat-button color="warn" [mat-dialog-close]="true">

--- a/library/src/app/components/bank-account-management/bank-account-disconnect/bank-account-disconnect.component.spec.ts
+++ b/library/src/app/components/bank-account-management/bank-account-disconnect/bank-account-disconnect.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BankAccountDisconnectComponent } from '@components';
+
+describe('BankAccountDisconnectComponent', () => {
+  let component: BankAccountDisconnectComponent;
+  let fixture: ComponentFixture<BankAccountDisconnectComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ BankAccountDisconnectComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(BankAccountDisconnectComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/library/src/app/components/bank-account-management/bank-account-disconnect/bank-account-disconnect.component.spec.ts
+++ b/library/src/app/components/bank-account-management/bank-account-disconnect/bank-account-disconnect.component.spec.ts
@@ -1,16 +1,49 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { BankAccountDisconnectComponent } from '@components';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { TestConstants } from '@constants';
+import { CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA } from '@angular/core';
+import {
+  TranslateLoader,
+  TranslateModule,
+  TranslatePipe
+} from '@ngx-translate/core';
+import { HttpLoaderFactory } from '../../../modules/library.module';
+import { HttpClient } from '@angular/common/http';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('BankAccountDisconnectComponent', () => {
   let component: BankAccountDisconnectComponent;
   let fixture: ComponentFixture<BankAccountDisconnectComponent>;
 
+  let MockDialogRef = jasmine.createSpyObj('MatDialogRef', ['open', 'close']);
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ BankAccountDisconnectComponent ]
-    })
-    .compileComponents();
+      imports: [
+        BrowserAnimationsModule,
+        HttpClientTestingModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useFactory: HttpLoaderFactory,
+            deps: [HttpClient]
+          }
+        })
+      ],
+      declarations: [BankAccountDisconnectComponent],
+      providers: [
+        { provide: MatDialogRef, useValue: MockDialogRef },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL
+        },
+        TranslatePipe
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(BankAccountDisconnectComponent);
     component = fixture.componentInstance;

--- a/library/src/app/components/bank-account-management/bank-account-disconnect/bank-account-disconnect.component.ts
+++ b/library/src/app/components/bank-account-management/bank-account-disconnect/bank-account-disconnect.component.ts
@@ -1,0 +1,18 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-bank-account-disconnect',
+  templateUrl: './bank-account-disconnect.component.html',
+  styleUrls: ['./bank-account-disconnect.component.scss']
+})
+export class BankAccountDisconnectComponent {
+  accountName!: string;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: string,
+    public dialogRef: MatDialogRef<BankAccountDisconnectComponent>
+  ) {
+    this.accountName = data;
+  }
+}

--- a/library/src/app/components/bank-account-management/bank-account-list/bank-account-list.component.html
+++ b/library/src/app/components/bank-account-management/bank-account-list/bank-account-list.component.html
@@ -18,12 +18,7 @@
       >
         <!-- Account -->
         <ng-container matColumnDef="account">
-          <th
-            mat-header-cell
-            *matHeaderCellDef
-            mat-sort-header=""
-            arrowPosition="after"
-          >
+          <th mat-header-cell *matHeaderCellDef mat-sort-header="">
             <div class="cybrid-sort-header">
               {{ 'bankAccountList.account' | translate }}
             </div>
@@ -32,7 +27,7 @@
             <div class="cybrid-account-cell">
               <mat-icon>savings</mat-icon>
               <div class="bank-account-name">
-                <span>{{ account.name }}</span>
+                <span>{{ account.name + ' - ' + account.asset + ' ' }}</span>
                 <span class="mat-hint">{{
                   '(***' + account.plaid_account_mask + ')'
                 }}</span>
@@ -43,44 +38,32 @@
 
         <!-- Status -->
         <ng-container matColumnDef="status">
-          <th mat-header-cell *matHeaderCellDef>
+          <th
+            mat-header-cell
+            *matHeaderCellDef
+            mat-sort-header=""
+            arrowPosition="before"
+          >
             <div class="cybrid-sort-header">
               {{ 'bankAccountList.status' | translate }}
             </div>
           </th>
           <td id="status" mat-cell *matCellDef="let account">
             <div class="cybrid-status-cell">
-              <ng-container [ngSwitch]="account.state">
-                <mat-icon *ngSwitchCase="'storing'" color="primary"
-                  >check_circle</mat-icon
-                >
-                <mat-icon *ngSwitchCase="'completed'" color="primary"
-                  >check_circle</mat-icon
-                >
-                <mat-icon *ngSwitchCase="'failed'" color="warn"
-                  >cancel</mat-icon
-                >
-                <button
-                  id="refresh"
-                  *ngSwitchCase="'refresh_required'"
-                  mat-icon-button
-                  (click)="onAccountRefresh(account)"
-                >
-                  <mat-icon color="warn">refresh</mat-icon>
-                </button>
-                <mat-icon *ngSwitchCase="'deleting'" color="warn"
-                  >auto_delete</mat-icon
-                >
-                <mat-icon *ngSwitchCase="'deleted'" color="warn"
-                  >delete</mat-icon
-                >
-              </ng-container>
+              <span>{{
+                'bankAccountList.state.' + account.state | translate
+              }}</span>
             </div>
           </td>
         </ng-container>
 
         <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: displayedColumns"
+          class="cybrid-pointer"
+          (click)="onAccountSelect(row)"
+        ></tr>
         <tr class="mat-row" *matNoDataRow>
           <td id="warning" class="mat-cell cybrid-no-data" colspan="2">
             No bank accounts connected.
@@ -101,7 +84,12 @@
   >
   </mat-paginator>
   <div *ngIf="(isLoading$ | async) !== true" class="cybrid-actions">
-    <button id="add-account" mat-flat-button color="primary" (click)="onAddAccount()">
+    <button
+      id="add-account"
+      mat-flat-button
+      color="primary"
+      (click)="onAddAccount()"
+    >
       {{ 'bankAccountList.addAccount' | translate }}
     </button>
   </div>

--- a/library/src/app/components/bank-account-management/bank-account-list/bank-account-list.component.html
+++ b/library/src/app/components/bank-account-management/bank-account-list/bank-account-list.component.html
@@ -3,22 +3,24 @@
   <ng-container *ngIf="(isLoading$ | async) !== true; else loading">
     <div class="cybrid-table">
       <mat-progress-bar
-        *ngIf="isLoadingResults"
+        *ngIf="isLoadingResults$ | async"
         mode="indeterminate"
       ></mat-progress-bar>
       <table
         id="bank-account-list"
+        class="mat-button-toggle-group-appearance-standard"
+        [ngClass]="{ 'cybrid-paginator': dataSource.data.length > 5 }"
         mat-table
         matSort
         matSortDisableClear
-        (matSortChange)="sortChange()"
         [dataSource]="dataSource"
-        class="mat-button-toggle-group-appearance-standard"
-        [ngClass]="{ 'cybrid-paginator': totalRows > 5 }"
+        matSortActive="status"
+        matSortDirection="asc"
+        (matSortChange)="sortChange()"
       >
         <!-- Account -->
         <ng-container matColumnDef="account">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header="">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header="account">
             <div class="cybrid-sort-header">
               {{ 'bankAccountList.account' | translate }}
             </div>
@@ -41,7 +43,7 @@
           <th
             mat-header-cell
             *matHeaderCellDef
-            mat-sort-header=""
+            mat-sort-header="status"
             arrowPosition="before"
           >
             <div class="cybrid-sort-header">
@@ -66,21 +68,23 @@
         ></tr>
         <tr class="mat-row" *matNoDataRow>
           <td id="warning" class="mat-cell cybrid-no-data" colspan="2">
-            No bank accounts connected.
+            {{
+              !listExternalBankAccountsError
+                ? ('bankAccountList.empty' | translate)
+                : ('bankAccountList.error' | translate)
+            }}
           </td>
         </tr>
       </table>
     </div>
   </ng-container>
   <mat-paginator
-    [pageSize]="pageSize"
-    [pageIndex]="currentPage"
-    [length]="totalRows"
-    [pageSizeOptions]="pageSizeOptions"
-    (page)="pageChange($event)"
+    aria-label="bank accounts paginator"
     class="mat-button-toggle-group-appearance-standard"
-    [ngClass]="{ 'cybrid-hide': totalRows <= 5 }"
-    aria-label="bank accounts"
+    [ngClass]="{ 'cybrid-hide': dataSource.data.length <= 5 }"
+    [length]="dataSource.data.length"
+    [pageSize]="pageSize"
+    [pageSizeOptions]="pageSizeOptions"
   >
   </mat-paginator>
   <div *ngIf="(isLoading$ | async) !== true" class="cybrid-actions">

--- a/library/src/app/components/bank-account-management/bank-account-list/bank-account-list.component.scss
+++ b/library/src/app/components/bank-account-management/bank-account-list/bank-account-list.component.scss
@@ -57,6 +57,3 @@ td.mat-cell:last-of-type {
 .cybrid-hide {
   display: none;
 }
-
-//@media screen and (max-width: 599px) {
-//}

--- a/library/src/app/components/bank-account-management/bank-account-list/bank-account-list.component.scss
+++ b/library/src/app/components/bank-account-management/bank-account-list/bank-account-list.component.scss
@@ -58,5 +58,5 @@ td.mat-cell:last-of-type {
   display: none;
 }
 
-@media screen and (max-width: 599px) {
-}
+//@media screen and (max-width: 599px) {
+//}

--- a/library/src/app/components/bank-account-management/bank-account-list/bank-account-list.component.spec.ts
+++ b/library/src/app/components/bank-account-management/bank-account-list/bank-account-list.component.spec.ts
@@ -1,14 +1,27 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  discardPeriodicTasks,
+  fakeAsync,
+  TestBed,
+  tick
+} from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { HttpLoaderFactory } from '../../../modules/library.module';
 import { HttpClient } from '@angular/common/http';
-import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
-import { ExternalBankAccountsService } from '@cybrid/cybrid-api-bank-angular';
+import {
+  MAT_DIALOG_DATA,
+  MatDialog,
+  MatDialogModule
+} from '@angular/material/dialog';
+import {
+  ExternalBankAccountListBankModel,
+  ExternalBankAccountsService
+} from '@cybrid/cybrid-api-bank-angular';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 
-import { of, throwError } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 
 // Services
 import { ConfigService, RoutingService } from '@services';
@@ -16,9 +29,11 @@ import { ConfigService, RoutingService } from '@services';
 // Components
 import { BankAccountListComponent } from '@components';
 
-// Utility
-import { TestConstants } from '@constants';
+// Models
 import { ExternalBankAccountBankModel } from '@cybrid/cybrid-api-bank-angular/model/externalBankAccount';
+
+// Utility
+import { Constants, TestConstants } from '@constants';
 import { SharedModule } from '../../../../shared/modules/shared.module';
 
 describe('BankAccountListComponent', () => {
@@ -39,6 +54,8 @@ describe('BankAccountListComponent', () => {
       )
     }
   );
+  let MockDialog = jasmine.createSpyObj('Dialog', ['open']);
+
   const error$ = throwError(() => {
     new Error('Error');
   });
@@ -66,7 +83,8 @@ describe('BankAccountListComponent', () => {
           provide: ExternalBankAccountsService,
           useValue: MockExternalBankAccountService
         },
-        { provide: MAT_DIALOG_DATA, useValue: {} }
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: MockDialog }
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
@@ -76,10 +94,18 @@ describe('BankAccountListComponent', () => {
     MockExternalBankAccountService = TestBed.inject(
       ExternalBankAccountsService
     );
+    MockDialog.open.and.returnValue({ afterClosed: () => of(true) });
 
     fixture = TestBed.createComponent(BankAccountListComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    MockExternalBankAccountService.listExternalBankAccounts.calls.reset();
+    MockExternalBankAccountService.listExternalBankAccounts.and.returnValue(
+      of(TestConstants.EXTERNAL_BANK_ACCOUNT_LIST_BANK_MODEL)
+    );
   });
 
   it('should create', () => {
@@ -104,23 +130,74 @@ describe('BankAccountListComponent', () => {
     expect(defaultSort).toEqual('');
   });
 
+  it('should page through external bank accounts', () => {
+    let externalBankAccountList = {
+      ...TestConstants.EXTERNAL_BANK_ACCOUNT_LIST_BANK_MODEL
+    };
+    externalBankAccountList.objects = [];
+
+    // Fill objects with default amount per page
+    for (let i = 0; i < 10; i++) {
+      externalBankAccountList.objects.push(
+        TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL
+      );
+    }
+
+    MockExternalBankAccountService.listExternalBankAccounts.and.returnValue(
+      of(externalBankAccountList)
+    );
+
+    component.listExternalBankAccounts();
+    expect(
+      component.pageExternalAccounts(externalBankAccountList)
+    ).toBeInstanceOf(Observable<ExternalBankAccountListBankModel>);
+  });
+
   it('should navigate to bank-connect onAddAccount()', () => {
     component.listExternalBankAccounts();
     component.onAddAccount();
     expect(MockRoutingService.handleRoute).toHaveBeenCalled();
   });
 
-  // it('should navigate to bank-connect with the account guid onAccountRefresh()', () => {
-  //   let mockRoutingData = { ...component.routingData };
-  //   mockRoutingData.extras = {
-  //     queryParams: {
-  //       externalAccountGuid: TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL.guid
-  //     }
-  //   };
-  //
-  //   component.onAccountRefresh(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL);
-  //   expect(MockRoutingService.handleRoute).toHaveBeenCalledWith(
-  //     mockRoutingData
-  //   );
-  // });
+  it('should handle errors on listExternalBankAccounts()', () => {
+    const refreshDataSubSpy = spyOn(component.refreshDataSub, 'unsubscribe');
+    const isLoadingSpy = spyOn(component.isLoading$, 'next');
+    MockExternalBankAccountService.listExternalBankAccounts.and.returnValue(
+      error$
+    );
+
+    component.listExternalBankAccounts();
+    expect(refreshDataSubSpy).toHaveBeenCalled();
+    expect(component.listExternalBankAccountsError).toBeTrue();
+    expect(component.dataSource.data).toEqual([]);
+    expect(isLoadingSpy).toHaveBeenCalled();
+  });
+
+  it('should refresh the external bank account list', fakeAsync(() => {
+    const listExternalBankAccountsSpy = spyOn(
+      component,
+      'listExternalBankAccounts'
+    );
+
+    component.refreshData();
+    tick(Constants.REFRESH_INTERVAL);
+    expect(listExternalBankAccountsSpy).toHaveBeenCalled();
+
+    discardPeriodicTasks();
+  }));
+
+  it('should open the bank-account-details dialog onAccountSelect()', () => {
+    component.onAccountSelect(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL);
+    expect(MockDialog.open).toHaveBeenCalled();
+  });
+
+  it('should list external bank accounts if the bank-account-details dialog returns true', () => {
+    const listExternalBankAccountsSpy = spyOn(
+      component,
+      'listExternalBankAccounts'
+    );
+
+    component.onAccountSelect(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL);
+    expect(listExternalBankAccountsSpy).toHaveBeenCalled();
+  });
 });

--- a/library/src/app/components/bank-account-management/bank-account-list/bank-account-list.component.spec.ts
+++ b/library/src/app/components/bank-account-management/bank-account-list/bank-account-list.component.spec.ts
@@ -3,24 +3,17 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { HttpLoaderFactory } from '../../../modules/library.module';
 import { HttpClient } from '@angular/common/http';
-import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { ExternalBankAccountsService } from '@cybrid/cybrid-api-bank-angular';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 
-import { PageEvent } from '@angular/material/paginator';
-
 import { of, throwError } from 'rxjs';
 
 // Services
-import {
-  ConfigService,
-  ErrorService,
-  EventService,
-  RoutingService
-} from '@services';
-// Components
+import { ConfigService, RoutingService } from '@services';
 
+// Components
 import { BankAccountListComponent } from '@components';
 
 // Utility
@@ -35,14 +28,6 @@ describe('BankAccountListComponent', () => {
   let MockConfigService = jasmine.createSpyObj('ConfigService', {
     getConfig$: of(TestConstants.CONFIG)
   });
-  let MockEventService = jasmine.createSpyObj('EventService', [
-    'getEvent',
-    'handleEvent'
-  ]);
-  let MockErrorService = jasmine.createSpyObj('ErrorService', [
-    'getError',
-    'handleError'
-  ]);
   let MockRoutingService = jasmine.createSpyObj('RoutingService', [
     'handleRoute'
   ]);
@@ -64,6 +49,7 @@ describe('BankAccountListComponent', () => {
       imports: [
         BrowserAnimationsModule,
         HttpClientTestingModule,
+        MatDialogModule,
         SharedModule,
         TranslateModule.forRoot({
           loader: {
@@ -74,8 +60,6 @@ describe('BankAccountListComponent', () => {
         })
       ],
       providers: [
-        { provide: EventService, useValue: MockEventService },
-        { provide: ErrorService, useValue: MockErrorService },
         { provide: RoutingService, useValue: MockRoutingService },
         { provide: ConfigService, useValue: MockConfigService },
         {
@@ -86,8 +70,6 @@ describe('BankAccountListComponent', () => {
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
-    MockEventService = TestBed.inject(EventService);
-    MockErrorService = TestBed.inject(ErrorService);
     MockRoutingService = TestBed.inject(RoutingService);
     MockConfigService = TestBed.inject(ConfigService);
     MockConfigService.getConfig$.and.returnValue(of(TestConstants.CONFIG));
@@ -104,30 +86,10 @@ describe('BankAccountListComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should handle errors on listBankAccounts()', () => {
-    MockExternalBankAccountService.listExternalBankAccounts.and.returnValue(
-      error$
-    );
-
-    component.getExternalBankAccounts();
-    expect(MockEventService.handleEvent).toHaveBeenCalled();
-    expect(MockErrorService.handleError).toHaveBeenCalled();
-  });
-
-  it('should get accounts on page change', () => {
-    const listBankAccountsSpy = spyOn(component, 'getExternalBankAccounts');
-    const testPageChange: PageEvent = {
-      length: 0,
-      pageIndex: 0,
-      pageSize: 5
-    };
-
-    component.pageChange(testPageChange);
-    expect(listBankAccountsSpy).toHaveBeenCalled();
-  });
-
   it('should sort the datasource', () => {
+    component.listExternalBankAccounts();
     component.sortChange();
+
     expect(component.dataSource.sort).toEqual(component.sort);
 
     let account: ExternalBankAccountBankModel =
@@ -143,21 +105,22 @@ describe('BankAccountListComponent', () => {
   });
 
   it('should navigate to bank-connect onAddAccount()', () => {
+    component.listExternalBankAccounts();
     component.onAddAccount();
     expect(MockRoutingService.handleRoute).toHaveBeenCalled();
   });
 
-  it('should navigate to bank-connect with the account guid onAccountRefresh()', () => {
-    let mockRoutingData = { ...component.routingData };
-    mockRoutingData.extras = {
-      queryParams: {
-        externalAccountGuid: TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL.guid
-      }
-    };
-
-    component.onAccountRefresh(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL);
-    expect(MockRoutingService.handleRoute).toHaveBeenCalledWith(
-      mockRoutingData
-    );
-  });
+  // it('should navigate to bank-connect with the account guid onAccountRefresh()', () => {
+  //   let mockRoutingData = { ...component.routingData };
+  //   mockRoutingData.extras = {
+  //     queryParams: {
+  //       externalAccountGuid: TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL.guid
+  //     }
+  //   };
+  //
+  //   component.onAccountRefresh(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL);
+  //   expect(MockRoutingService.handleRoute).toHaveBeenCalledWith(
+  //     mockRoutingData
+  //   );
+  // });
 });

--- a/library/src/app/components/bank-account-management/bank-account-list/bank-account-list.component.ts
+++ b/library/src/app/components/bank-account-management/bank-account-list/bank-account-list.component.ts
@@ -18,7 +18,6 @@ import {
   switchMap,
   takeUntil,
   tap,
-  throwError,
   timer
 } from 'rxjs';
 
@@ -39,9 +38,6 @@ import { BankAccountDetailsComponent } from '../bank-account-details/bank-accoun
 // Models
 import { ExternalBankAccountBankModel } from '@cybrid/cybrid-api-bank-angular/model/externalBankAccount';
 import { ExternalBankAccountListBankModel } from '@cybrid/cybrid-api-bank-angular';
-
-// Utility
-import { TestConstants } from '@constants';
 
 @Component({
   selector: 'app-bank-account-list',
@@ -70,8 +66,6 @@ export class BankAccountListComponent implements OnInit, OnDestroy {
 
   pageSize = 5;
   pageSizeOptions: number[] = [5, 10, 25, 100];
-
-  externalBankAccountsPerPage = 10;
 
   isLoading$ = new BehaviorSubject(true);
   isLoadingResults$ = new BehaviorSubject(true);
@@ -128,11 +122,10 @@ export class BankAccountListComponent implements OnInit, OnDestroy {
   pageExternalAccounts(
     list: ExternalBankAccountListBankModel
   ): Observable<ExternalBankAccountListBankModel> | Observable<never> {
-    const perPage = Number(list.per_page);
-    const nextPage = (perPage + 1).toString();
-
-    return list.objects.length == perPage
-      ? this.bankAccountService.listExternalBankAccounts(nextPage)
+    return list.objects.length == Number(list.per_page)
+      ? this.bankAccountService.listExternalBankAccounts(
+          Number(list.page + 1).toString()
+        )
       : EMPTY;
   }
 
@@ -160,7 +153,6 @@ export class BankAccountListComponent implements OnInit, OnDestroy {
               account.state == 'refresh_required'
           )
         ),
-        switchMap(() => throwError(() => new Error('error me harder'))),
         map((accounts) => (this.dataSource.data = accounts)),
         catchError((err) => {
           this.refreshDataSub.unsubscribe();

--- a/library/src/app/components/bank-account-management/bank-account-list/bank-account-list.component.ts
+++ b/library/src/app/components/bank-account-management/bank-account-list/bank-account-list.component.ts
@@ -17,7 +17,6 @@ import {
   Subscription,
   switchMap,
   takeUntil,
-  tap,
   timer
 } from 'rxjs';
 
@@ -176,7 +175,7 @@ export class BankAccountListComponent implements OnInit, OnDestroy {
           return timer(cfg.refreshInterval, cfg.refreshInterval);
         }),
         takeUntil(this.unsubscribe$),
-        tap(() => this.listExternalBankAccounts())
+        map(() => this.listExternalBankAccounts())
       )
       .subscribe();
   }

--- a/library/src/app/components/bank-account-management/index.ts
+++ b/library/src/app/components/bank-account-management/index.ts
@@ -1,3 +1,5 @@
 export { BankAccountConnectComponent } from './bank-account-connect/bank-account-connect.component';
 export { BankAccountConfirmComponent } from './bank-account-confirm/bank-account-confirm.component';
 export { BankAccountListComponent } from './bank-account-list/bank-account-list.component';
+export { BankAccountDetailsComponent } from './bank-account-details/bank-account-details.component';
+export { BankAccountDisconnectComponent } from './bank-account-disconnect/bank-account-disconnect.component';

--- a/library/src/app/modules/library.module.ts
+++ b/library/src/app/modules/library.module.ts
@@ -68,7 +68,8 @@ import {
   TransferComponent,
   TransferConfirmComponent,
   TransferDetailsComponent,
-  BankAccountListComponent
+  BankAccountListComponent,
+  BankAccountDisconnectComponent
 } from '@components';
 
 // Utility
@@ -80,6 +81,7 @@ import {
   AssetFormatPipe
 } from '@pipes';
 import { CustomPaginatorIntl } from '@utility';
+import { BankAccountDetailsComponent } from '../components/bank-account-management/bank-account-details/bank-account-details.component';
 
 export function HttpLoaderFactory(http: HttpClient) {
   return new TranslateHttpLoader(http);
@@ -105,6 +107,8 @@ export function HttpLoaderFactory(http: HttpClient) {
     BankAccountConnectComponent,
     BankAccountConfirmComponent,
     BankAccountListComponent,
+    BankAccountDetailsComponent,
+    BankAccountDisconnectComponent,
     TransferComponent,
     TransferConfirmComponent,
     TransferDetailsComponent,

--- a/library/src/shared/i18n/en.ts
+++ b/library/src/shared/i18n/en.ts
@@ -5,6 +5,8 @@ export default {
   done: 'DONE',
   begin: 'BEGIN',
   resume: 'RESUME',
+  disconnect: 'DISCONNECT',
+  reconnect: 'RECONNECT',
   back: 'Back',
   date: 'Date',
   to: 'To',
@@ -172,6 +174,8 @@ export default {
     account: 'Account',
     status: 'Status',
     addAccount: 'ADD ACCOUNT',
+    empty: 'No bank accounts connected.',
+    error: 'Error fetching bank accounts.',
     state: {
       storing: 'Pending',
       completed: 'Connected',
@@ -179,6 +183,15 @@ export default {
       refresh_required: 'Refresh required',
       deleting: 'Disconnecting...',
       deleted: 'Disconnected'
+    },
+
+    // Details dialog
+    details: {
+      title: 'Account Details',
+      name: 'Name',
+      asset: 'Asset',
+      number: 'Number',
+      status: 'Status'
     }
   },
 

--- a/library/src/shared/i18n/en.ts
+++ b/library/src/shared/i18n/en.ts
@@ -171,7 +171,15 @@ export default {
   bankAccountList: {
     account: 'Account',
     status: 'Status',
-    addAccount: 'ADD ACCOUNT'
+    addAccount: 'ADD ACCOUNT',
+    state: {
+      storing: 'Pending',
+      completed: 'Connected',
+      failed: 'Failed',
+      refresh_required: 'Refresh required',
+      deleting: 'Disconnecting...',
+      deleted: 'Disconnected'
+    }
   },
 
   // Transfer component

--- a/library/src/shared/i18n/en.ts
+++ b/library/src/shared/i18n/en.ts
@@ -191,7 +191,16 @@ export default {
       name: 'Name',
       asset: 'Asset',
       number: 'Number',
-      status: 'Status'
+      status: 'Status',
+      success: 'Disconnected',
+      error: 'Error disconnecting'
+    },
+
+    // Disconnect dialog
+    disconnect: {
+      title: 'Confirm Disconnect',
+      confirm: 'Please confirm removal of',
+      warning: 'Deposits will no longer be possible from this account'
     }
   },
 

--- a/library/src/shared/i18n/fr.ts
+++ b/library/src/shared/i18n/fr.ts
@@ -5,6 +5,8 @@ export default {
   done: 'FAIT',
   begin: 'COMMENCER',
   resume: 'RECOMMENCER',
+  disconnect: 'DÉCONNECTER',
+  reconnect: 'RECONNECTER',
   back: 'Retourner',
   date: 'Date',
   to: 'À',
@@ -174,6 +176,8 @@ export default {
     account: 'Compte',
     status: 'Statut',
     addAccount: 'AJOUTER UN COMPTE',
+    empty: 'Aucun compte bancaire connecté.',
+    error: 'Erreur lors de la récupération des comptes bancaires.',
     state: {
       storing: 'En attente',
       completed: 'Connecté',
@@ -181,6 +185,15 @@ export default {
       refresh_required: 'Actualisation requise',
       deleting: 'Déconnexion...',
       deleted: 'Déconnecté'
+    },
+
+    // Details dialog
+    details: {
+      title: 'Détails du compte',
+      name: 'Nom',
+      asset: 'Actif',
+      number: 'Numéro',
+      status: 'Statut'
     }
   },
 

--- a/library/src/shared/i18n/fr.ts
+++ b/library/src/shared/i18n/fr.ts
@@ -193,7 +193,16 @@ export default {
       name: 'Nom',
       asset: 'Actif',
       number: 'Numéro',
-      status: 'Statut'
+      status: 'Statut',
+      success: 'Déconnecté',
+      error: 'Erreur lors de la déconnexion'
+    },
+
+    // Disconnect dialog
+    disconnect: {
+      title: 'Confirmer la déconnexion',
+      confirm: 'Veuillez confirmer la suppression de',
+      warning: 'Les dépôts ne seront plus possibles à partir de ce compte'
     }
   },
 

--- a/library/src/shared/i18n/fr.ts
+++ b/library/src/shared/i18n/fr.ts
@@ -173,7 +173,15 @@ export default {
   bankAccountList: {
     account: 'Compte',
     status: 'Statut',
-    addAccount: 'AJOUTER UN COMPTE'
+    addAccount: 'AJOUTER UN COMPTE',
+    state: {
+      storing: 'En attente',
+      completed: 'Connecté',
+      failed: 'Échoué',
+      refresh_required: 'Actualisation requise',
+      deleting: 'Déconnexion...',
+      deleted: 'Déconnecté'
+    }
   },
 
   // Transfer component

--- a/library/src/shared/services/bank-account/bank-account.service.spec.ts
+++ b/library/src/shared/services/bank-account/bank-account.service.spec.ts
@@ -34,7 +34,11 @@ describe('BankAccountManagementService', () => {
   });
   let MockExternalBankAccountService = jasmine.createSpyObj(
     'ExternalBankAccountsService',
-    ['listExternalBankAccounts', 'createExternalBankAccount']
+    [
+      'listExternalBankAccounts',
+      'createExternalBankAccount',
+      'deleteExternalBankAccount'
+    ]
   );
   let MockWorkflowService = jasmine.createSpyObj('WorkflowsService', [
     'createWorkflow',
@@ -80,7 +84,28 @@ describe('BankAccountManagementService', () => {
     MockExternalBankAccountService.createExternalBankAccount.and.returnValue(
       of(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL)
     );
+    MockExternalBankAccountService.deleteExternalBankAccount.and.returnValue(
+      of(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL)
+    );
     MockWorkflowService = TestBed.inject(WorkflowsService);
+    MockWorkflowService.createWorkflow.and.returnValue(
+      of(TestConstants.WORKFLOW_BANK_MODEL)
+    );
+    MockWorkflowService.getWorkflow.and.returnValue(
+      of(TestConstants.WORKFLOW_BANK_MODEL_WITH_DETAILS)
+    );
+  });
+
+  afterEach(() => {
+    MockExternalBankAccountService.listExternalBankAccounts.and.returnValue(
+      of(TestConstants.EXTERNAL_BANK_ACCOUNT_LIST_BANK_MODEL)
+    );
+    MockExternalBankAccountService.createExternalBankAccount.and.returnValue(
+      of(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL)
+    );
+    MockExternalBankAccountService.deleteExternalBankAccount.and.returnValue(
+      of(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL)
+    );
     MockWorkflowService.createWorkflow.and.returnValue(
       of(TestConstants.WORKFLOW_BANK_MODEL)
     );
@@ -149,6 +174,23 @@ describe('BankAccountManagementService', () => {
       );
   });
 
+  it('should delete an external bank account', () => {
+    service.deleteExternalBankAccount('').subscribe();
+    expect(
+      MockExternalBankAccountService.deleteExternalBankAccount
+    ).toHaveBeenCalled();
+  });
+
+  it('should catch any errors on deleteExternalBankAccount()', () => {
+    MockExternalBankAccountService.deleteExternalBankAccount.and.returnValue(
+      error$
+    );
+
+    service.deleteExternalBankAccount('').subscribe();
+    expect(MockErrorService.handleError).toHaveBeenCalled();
+    expect(MockEventService.handleEvent).toHaveBeenCalled();
+  });
+
   it('should create a link_token_create workflow', () => {
     const kind: PostWorkflowBankModel.KindEnum = 'link_token_create';
 
@@ -183,7 +225,7 @@ describe('BankAccountManagementService', () => {
       );
   });
 
-  it('should catch any errors on createExternalBankAccount', () => {
+  it('should catch any errors on createExternalBankAccount()', () => {
     MockExternalBankAccountService.createExternalBankAccount.and.returnValue(
       error$
     );
@@ -191,11 +233,6 @@ describe('BankAccountManagementService', () => {
     service.createExternalBankAccount('', '', '', '').subscribe();
     expect(MockEventService.handleEvent).toHaveBeenCalled();
     expect(MockErrorService.handleError).toHaveBeenCalled();
-
-    // Reset
-    MockExternalBankAccountService.createExternalBankAccount.and.returnValue(
-      of(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL)
-    );
   });
 
   it('should catch any errors on creating a link_token_create workflow', () => {
@@ -204,11 +241,6 @@ describe('BankAccountManagementService', () => {
     service.createWorkflow(PostWorkflowBankModel.KindEnum.Create).subscribe();
     expect(MockEventService.handleEvent).toHaveBeenCalled();
     expect(MockErrorService.handleError).toHaveBeenCalled();
-
-    // Reset
-    MockWorkflowService.createWorkflow.and.returnValue(
-      of(TestConstants.WORKFLOW_BANK_MODEL)
-    );
   });
 
   it('should catch any errors on creating a link_token_update workflow', () => {
@@ -219,11 +251,6 @@ describe('BankAccountManagementService', () => {
       .subscribe();
     expect(MockEventService.handleEvent).toHaveBeenCalled();
     expect(MockErrorService.handleError).toHaveBeenCalled();
-
-    // Reset
-    MockWorkflowService.createWorkflow.and.returnValue(
-      of(TestConstants.WORKFLOW_BANK_MODEL)
-    );
   });
 
   it('should get a workflow', () => {

--- a/library/src/shared/services/bank-account/bank-account.service.ts
+++ b/library/src/shared/services/bank-account/bank-account.service.ts
@@ -7,12 +7,19 @@ import {
   Observable,
   of,
   Subject,
-  switchMap,
-  takeUntil,
-  tap,
-  throwError
+  takeUntil
 } from 'rxjs';
 
+// Services
+import {
+  CODE,
+  ConfigService,
+  ErrorService,
+  EventService,
+  LEVEL
+} from '@services';
+
+// Models
 import {
   ExternalBankAccountBankModel,
   ExternalBankAccountListBankModel,
@@ -24,18 +31,8 @@ import {
   WorkflowWithDetailsBankModel
 } from '@cybrid/cybrid-api-bank-angular';
 
-// Services
-import {
-  CODE,
-  ConfigService,
-  ErrorService,
-  EventService,
-  LEVEL
-} from '@services';
-
 // Utility
 import { getLanguageFromLocale } from '../../utility/locale-language';
-import { TestConstants } from '@constants';
 
 @Injectable({
   providedIn: 'root'
@@ -148,8 +145,6 @@ export class BankAccountService implements OnDestroy {
     return this.externalBankAccountService
       .deleteExternalBankAccount(externalAccountGuid)
       .pipe(
-        // return of(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL).pipe(
-        //   switchMap(() => throwError(() => new Error('error'))),
         catchError((err: any) => {
           let message = 'There was an error deleting a bank account';
           this.eventService.handleEvent(LEVEL.ERROR, CODE.DATA_ERROR, message);
@@ -168,8 +163,8 @@ export class BankAccountService implements OnDestroy {
     postWorkflowBankModel.external_bank_account_guid = externalAccountGuid;
     return this.workflowService.createWorkflow(postWorkflowBankModel).pipe(
       catchError((err: any) => {
-        let message =
-          externalAccountGuid == undefined
+        const message =
+          externalAccountGuid !== undefined
             ? 'There was an error reconnecting a bank account'
             : 'There was an error creating a bank account';
         this.eventService.handleEvent(LEVEL.ERROR, CODE.DATA_ERROR, message);

--- a/library/src/shared/services/bank-account/bank-account.service.ts
+++ b/library/src/shared/services/bank-account/bank-account.service.ts
@@ -7,10 +7,14 @@ import {
   Observable,
   of,
   Subject,
-  takeUntil
+  switchMap,
+  takeUntil,
+  tap,
+  throwError
 } from 'rxjs';
 
 import {
+  ExternalBankAccountBankModel,
   ExternalBankAccountListBankModel,
   ExternalBankAccountsService,
   PostExternalBankAccountBankModel,
@@ -31,6 +35,7 @@ import {
 
 // Utility
 import { getLanguageFromLocale } from '../../utility/locale-language';
+import { TestConstants } from '@constants';
 
 @Injectable({
   providedIn: 'root'
@@ -121,6 +126,23 @@ export class BankAccountService implements OnDestroy {
       .pipe(
         catchError((err: any) => {
           let message = 'There was an error creating a bank account';
+          this.eventService.handleEvent(LEVEL.ERROR, CODE.DATA_ERROR, message);
+          this.errorService.handleError(new Error(message));
+          return of(err);
+        })
+      );
+  }
+
+  deleteExternalBankAccount(
+    externalAccountGuid: string
+  ): Observable<ExternalBankAccountBankModel> {
+    return this.externalBankAccountService
+      .deleteExternalBankAccount(externalAccountGuid)
+      .pipe(
+        // return of(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL).pipe(
+        //   switchMap(() => throwError(() => new Error('error'))),
+        catchError((err: any) => {
+          let message = 'There was an error deleting a bank account';
           this.eventService.handleEvent(LEVEL.ERROR, CODE.DATA_ERROR, message);
           this.errorService.handleError(new Error(message));
           return of(err);

--- a/library/src/shared/services/bank-account/bank-account.service.ts
+++ b/library/src/shared/services/bank-account/bank-account.service.ts
@@ -100,13 +100,22 @@ export class BankAccountService implements OnDestroy {
     page?: string,
     perPage?: string
   ): Observable<ExternalBankAccountListBankModel> {
-    return this.externalBankAccountService.listExternalBankAccounts(
-      page,
-      perPage,
-      undefined,
-      undefined,
-      this.customerGuid
-    );
+    return this.externalBankAccountService
+      .listExternalBankAccounts(
+        page,
+        perPage,
+        undefined,
+        undefined,
+        this.customerGuid
+      )
+      .pipe(
+        catchError((err) => {
+          const message = 'There was an error fetching bank account details';
+          this.eventService.handleEvent(LEVEL.ERROR, CODE.DATA_ERROR, message);
+          this.errorService.handleError(new Error(message));
+          return of(err);
+        })
+      );
   }
 
   createExternalBankAccount(
@@ -125,7 +134,7 @@ export class BankAccountService implements OnDestroy {
       .createExternalBankAccount(postExternalBankAccount)
       .pipe(
         catchError((err: any) => {
-          let message = 'There was an error creating a bank account';
+          const message = 'There was an error creating a bank account';
           this.eventService.handleEvent(LEVEL.ERROR, CODE.DATA_ERROR, message);
           this.errorService.handleError(new Error(message));
           return of(err);

--- a/library/src/shared/services/bank-account/bank-account.service.ts
+++ b/library/src/shared/services/bank-account/bank-account.service.ts
@@ -109,7 +109,7 @@ export class BankAccountService implements OnDestroy {
         catchError((err) => {
           const message = 'There was an error fetching bank account details';
           this.eventService.handleEvent(LEVEL.ERROR, CODE.DATA_ERROR, message);
-          this.errorService.handleError(new Error(message));
+          this.errorService.handleError(err);
           return of(err);
         })
       );
@@ -133,7 +133,7 @@ export class BankAccountService implements OnDestroy {
         catchError((err: any) => {
           const message = 'There was an error creating a bank account';
           this.eventService.handleEvent(LEVEL.ERROR, CODE.DATA_ERROR, message);
-          this.errorService.handleError(new Error(message));
+          this.errorService.handleError(err);
           return of(err);
         })
       );
@@ -148,7 +148,7 @@ export class BankAccountService implements OnDestroy {
         catchError((err: any) => {
           let message = 'There was an error deleting a bank account';
           this.eventService.handleEvent(LEVEL.ERROR, CODE.DATA_ERROR, message);
-          this.errorService.handleError(new Error(message));
+          this.errorService.handleError(err);
           return of(err);
         })
       );
@@ -168,7 +168,7 @@ export class BankAccountService implements OnDestroy {
             ? 'There was an error reconnecting a bank account'
             : 'There was an error creating a bank account';
         this.eventService.handleEvent(LEVEL.ERROR, CODE.DATA_ERROR, message);
-        this.errorService.handleError(new Error(message));
+        this.errorService.handleError(err);
         return of(err);
       })
     );


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [X] Feature
- [ ] Bug fix

### Linked issue
https://cybrid.atlassian.net/browse/CYB-842
https://cybrid.atlassian.net/browse/CYB-846
https://cybrid.atlassian.net/browse/CYB-845

### Why
We need to expand the bank account list to include bank accounts details. The `bank-account-details-component` needs to provide controls to reconnect or disconnect depending on the account state.

### How
Added a `bank-account-details-component`, and `bank-account-delete-component`.

<img width="663" alt="Screen Shot 2023-02-06 at 1 24 59 PM" src="https://user-images.githubusercontent.com/5817894/217056245-5ad45570-a33c-4321-839a-d96f90e0109d.png">
<img width="465" alt="Screen Shot 2023-02-06 at 1 25 11 PM" src="https://user-images.githubusercontent.com/5817894/217056283-5bf6c575-be24-4c52-be7d-d20983bd9cd3.png">
<img width="337" alt="Screen Shot 2023-02-06 at 1 30 18 PM" src="https://user-images.githubusercontent.com/5817894/217056331-f5ee24de-6251-4b05-80e2-7755eec343bc.png">
<img width="409" alt="Screen Shot 2023-02-06 at 1 29 59 PM" src="https://user-images.githubusercontent.com/5817894/217056355-61e306ff-8b44-4a2b-9a4e-73da52b32a3b.png">
<img width="371" alt="Screen Shot 2023-02-06 at 1 28 17 PM" src="https://user-images.githubusercontent.com/5817894/217056372-c4831d2e-affa-495b-9d05-b2dcdc4e4cf9.png">
<img width="586" alt="Screen Shot 2023-02-06 at 1 26 42 PM" src="https://user-images.githubusercontent.com/5817894/217056403-67890b79-f19b-43d4-ad16-54041cbfd7fa.png">
