### PR TITLE
fix: update IDV component for always create

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           command: |
             export LATEST=$(curl https://registry.npmjs.org/persona/latest | jq -r '. | .version')
             export CURRENT=$(grep 'PERSONA' -A 1 library/src/shared/constants/constants.ts | grep 'https' | sed 's/.*-v\(.*\).js.*/\1/')
-            if [[ "$LATEST" = "$CURRENT" ]]; then
+            if [ "$LATEST" = "$CURRENT" ] || [ "$LATEST" = "4.8.0-alpha" ]; then
               echo "Persona is up to date."
             else
               echo "Error: new Persona version available."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           command: |
             export LATEST=$(curl https://registry.npmjs.org/persona/latest | jq -r '. | .version')
             export CURRENT=$(grep 'PERSONA' -A 1 library/src/shared/constants/constants.ts | grep 'https' | sed 's/.*-v\(.*\).js.*/\1/')
-            if [ "$LATEST" = "$CURRENT" ] || [ "$LATEST" = "4.8.0-alpha" ]; then
+            if [[ "$LATEST" = "$CURRENT" ]]; then
               echo "Persona is up to date."
             else
               echo "Error: new Persona version available."

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -18,5 +18,5 @@ export default defineConfig({
   e2e: {
     baseUrl: 'http://localhost:4200',
     excludeSpecPattern: 'cypress/e2e/trade.cy.ts'
-  },
+  }
 });

--- a/library/src/app/components/identity-verification/identity-verification.component.spec.ts
+++ b/library/src/app/components/identity-verification/identity-verification.component.spec.ts
@@ -43,6 +43,7 @@ describe('IdentityVerificationComponent', () => {
     'IdentityVerificationService',
     [
       'getCustomer',
+      'createIdentityVerification',
       'getIdentityVerification',
       'getPersonaClient',
       'setPersonaClient'
@@ -91,6 +92,9 @@ describe('IdentityVerificationComponent', () => {
     );
     MockIdentityVerificationService.getCustomer.and.returnValue(
       of(TestConstants.CUSTOMER_BANK_MODEL)
+    );
+    MockIdentityVerificationService.createIdentityVerification.and.returnValue(
+      of(TestConstants.IDENTITY_VERIFICATION_BANK_MODEL)
     );
     MockIdentityVerificationService.getIdentityVerification.and.returnValue(
       of(TestConstants.IDENTITY_VERIFICATION_BANK_MODEL)
@@ -144,6 +148,36 @@ describe('IdentityVerificationComponent', () => {
     discardPeriodicTasks();
   }));
 
+  it('should check identity', fakeAsync(() => {
+    let mockIdentityWithOutcome = {
+      ...TestConstants.IDENTITY_VERIFICATION_BANK_MODEL
+    };
+    mockIdentityWithOutcome.outcome = 'passed';
+    MockIdentityVerificationService.getIdentityVerification.and.returnValue(
+      of(mockIdentityWithOutcome)
+    );
+
+    const handleIdentityVerificationStateSpy = spyOn(
+      component,
+      'handleIdentityVerificationState'
+    );
+
+    component.checkIdentity();
+
+    tick();
+    expect(
+      MockIdentityVerificationService.getIdentityVerification
+    ).toHaveBeenCalled();
+    expect(handleIdentityVerificationStateSpy).toHaveBeenCalled();
+
+    discardPeriodicTasks();
+
+    // Reset
+    MockIdentityVerificationService.getIdentityVerification.and.returnValue(
+      of(TestConstants.IDENTITY_VERIFICATION_BANK_MODEL)
+    );
+  }));
+
   it('should timeout after polling', fakeAsync(() => {
     const identitySpy = spyOn(component.identity$, 'next');
     let identity = { ...TestConstants.IDENTITY_VERIFICATION_BANK_MODEL };
@@ -186,7 +220,7 @@ describe('IdentityVerificationComponent', () => {
   }));
 
   it('should handle errors when calling verifyIdentity()', fakeAsync(() => {
-    MockIdentityVerificationService.getIdentityVerification.and.returnValue(
+    MockIdentityVerificationService.createIdentityVerification.and.returnValue(
       error$
     );
 

--- a/library/src/shared/constants/constants.ts
+++ b/library/src/shared/constants/constants.ts
@@ -25,7 +25,7 @@ export class Constants {
   static ROUTING = true;
   static ICON_HOST = 'https://images.cybrid.xyz/sdk/assets/svg/color/';
   static PERSONA_SCRIPT_SRC =
-    'https://cdn.withpersona.com/dist/persona-v4.7.2.js';
+    'https://cdn.withpersona.com/dist/persona-v4.8.0-alpha.js';
   static PLAID_SCRIPT_SRC =
     'https://cdn.plaid.com/link/v2/stable/link-initialize.js';
   static BTC_ICON = 'https://images.cybrid.xyz/sdk/assets/svg/color/btc.svg';

--- a/library/src/shared/services/identity-verification/identity-verification.service.spec.ts
+++ b/library/src/shared/services/identity-verification/identity-verification.service.spec.ts
@@ -146,21 +146,4 @@ describe('IdentityVerificationService', () => {
       TestConstants.IDENTITY_VERIFICATION_BANK_MODEL
     );
   });
-
-  it('should set the Persona client', () => {
-    const setPersonaSpy = spyOn(service.personaClient, 'next');
-
-    service.setPersonaClient('test');
-
-    expect(setPersonaSpy).toHaveBeenCalledWith('test');
-  });
-
-  it('should get the Persona client', () => {
-    // Set Persona client
-    service.setPersonaClient('test');
-
-    service.getPersonaClient().subscribe((res) => {
-      expect(res).toEqual('test');
-    });
-  });
 });

--- a/library/src/shared/services/identity-verification/identity-verification.service.spec.ts
+++ b/library/src/shared/services/identity-verification/identity-verification.service.spec.ts
@@ -4,9 +4,14 @@ import { TestBed } from '@angular/core/testing';
 
 import { HttpLoaderFactory } from '../../../app/modules/library.module';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
-import { ConfigService, IdentityVerificationService } from '@services';
+import {
+  ConfigService,
+  ErrorService,
+  EventService,
+  IdentityVerificationService
+} from '@services';
 import { TestConstants } from '@constants';
 import {
   CustomersService,
@@ -18,23 +23,24 @@ describe('IdentityVerificationService', () => {
   let MockConfigService = jasmine.createSpyObj('ConfigService', {
     getConfig$: of(TestConstants.CONFIG)
   });
+  let MockEventService = jasmine.createSpyObj('EventService', [
+    'getEvent',
+    'handleEvent'
+  ]);
+  let MockErrorService = jasmine.createSpyObj('ErrorService', [
+    'getError',
+    'handleError'
+  ]);
   let MockCustomersService = jasmine.createSpyObj('CustomersService', {
     getCustomer: of(TestConstants.CUSTOMER_BANK_MODEL)
   });
   let MockIdentityVerificationsService = jasmine.createSpyObj(
     'IdentityVerificationsService',
-    {
-      createIdentityVerification: of(
-        TestConstants.IDENTITY_VERIFICATION_BANK_MODEL
-      ),
-      listIdentityVerifications: of(
-        TestConstants.IDENTITY_VERIFICATION_LIST_BANK_MODEL
-      ),
-      getIdentityVerification: of(
-        TestConstants.IDENTITY_VERIFICATION_BANK_MODEL
-      )
-    }
+    ['createIdentityVerification', 'getIdentityVerification']
   );
+  const error$ = throwError(() => {
+    new Error('Error');
+  });
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -49,6 +55,8 @@ describe('IdentityVerificationService', () => {
         })
       ],
       providers: [
+        { provide: EventService, useValue: MockEventService },
+        { provide: ErrorService, useValue: MockErrorService },
         { provide: ConfigService, useValue: MockConfigService },
         { provide: CustomersService, useValue: MockCustomersService },
         {
@@ -59,7 +67,15 @@ describe('IdentityVerificationService', () => {
     });
     service = TestBed.inject(IdentityVerificationService);
     MockConfigService = TestBed.inject(ConfigService);
+    MockEventService = TestBed.inject(EventService);
+    MockErrorService = TestBed.inject(ErrorService);
     MockCustomersService = TestBed.inject(CustomersService);
+    MockIdentityVerificationsService.createIdentityVerification.and.returnValue(
+      of(TestConstants.IDENTITY_VERIFICATION_BANK_MODEL)
+    );
+    MockIdentityVerificationsService.getIdentityVerification.and.returnValue(
+      of(TestConstants.IDENTITY_VERIFICATION_BANK_MODEL)
+    );
     MockIdentityVerificationsService = TestBed.inject(
       IdentityVerificationsService
     );
@@ -83,74 +99,52 @@ describe('IdentityVerificationService', () => {
   });
 
   it('should create an identity verification', () => {
-    service.createIdentityVerification();
+    service
+      .createIdentityVerification()
+      .subscribe((res) =>
+        expect(res).toEqual(TestConstants.IDENTITY_VERIFICATION_BANK_MODEL)
+      );
+  });
 
-    expect(
-      MockIdentityVerificationsService.createIdentityVerification
-    ).toHaveBeenCalledWith(service.postIdentityVerificationBankModel);
+  it('should handle errors on creating an identity verification', () => {
+    MockIdentityVerificationsService.createIdentityVerification.and.returnValue(
+      error$
+    );
+
+    service.createIdentityVerification().subscribe();
+
+    expect(MockErrorService.handleError).toHaveBeenCalled();
+    expect(MockEventService.handleEvent).toHaveBeenCalled();
+
+    // Reset
+    MockIdentityVerificationsService.createIdentityVerification.and.returnValue(
+      of(TestConstants.IDENTITY_VERIFICATION_BANK_MODEL)
+    );
   });
 
   it('should get an identity verification', () => {
     // Default with existing identity verification
-    service.getIdentityVerification().subscribe();
+    service.getIdentityVerification('').subscribe();
 
     expect(
-      MockIdentityVerificationsService.listIdentityVerifications
-    ).toHaveBeenCalled();
-
-    // No existing identity verification
-    let emptyList = { ...TestConstants.IDENTITY_VERIFICATION_LIST_BANK_MODEL };
-    emptyList.objects = [];
-    MockIdentityVerificationsService.listIdentityVerifications.and.returnValue(
-      of(emptyList)
-    );
-
-    service.getIdentityVerification().subscribe();
-
-    expect(
-      MockIdentityVerificationsService.listIdentityVerifications
+      MockIdentityVerificationsService.getIdentityVerification
     ).toHaveBeenCalled();
   });
 
-  it('should handle an identity verification', () => {
-    // Valid identity and Persona state
-    let identity = service.handleIdentityVerificationState(
+  it('should handle error on getIdentityVerification()', () => {
+    MockIdentityVerificationsService.getIdentityVerification.and.returnValue(
+      error$
+    );
+
+    service.getIdentityVerification('').subscribe();
+
+    expect(MockErrorService.handleError).toHaveBeenCalled();
+    expect(MockEventService.handleEvent).toHaveBeenCalled();
+
+    // Reset
+    MockIdentityVerificationsService.getIdentityVerification.and.returnValue(
       TestConstants.IDENTITY_VERIFICATION_BANK_MODEL
     );
-
-    identity.subscribe((res) => {
-      expect(res).toEqual(TestConstants.IDENTITY_VERIFICATION_BANK_MODEL);
-    });
-
-    // Expired identity state
-    let expiredIdentity = {
-      ...TestConstants.IDENTITY_VERIFICATION_BANK_MODEL
-    };
-    expiredIdentity.state = 'expired';
-    MockIdentityVerificationsService.getIdentityVerification.and.returnValue(
-      of(expiredIdentity)
-    );
-
-    service.handleIdentityVerificationState(expiredIdentity).subscribe(() => {
-      expect(
-        MockIdentityVerificationsService.getIdentityVerification
-      ).toHaveBeenCalled();
-    });
-
-    // Expired Persona state
-    let expiredPersona = { ...TestConstants.IDENTITY_VERIFICATION_BANK_MODEL };
-    expiredPersona.persona_state = 'expired';
-    MockIdentityVerificationsService.getIdentityVerification.and.returnValue(
-      of(expiredIdentity)
-    );
-
-    service
-      .handleIdentityVerificationState(expiredIdentity)
-      .subscribe(() =>
-        expect(
-          MockIdentityVerificationsService.getIdentityVerification
-        ).toHaveBeenCalled()
-      );
   });
 
   it('should set the Persona client', () => {

--- a/library/src/shared/services/identity-verification/identity-verification.service.ts
+++ b/library/src/shared/services/identity-verification/identity-verification.service.ts
@@ -3,11 +3,11 @@ import { HttpClient } from '@angular/common/http';
 
 import {
   BehaviorSubject,
+  catchError,
   map,
   Observable,
   of,
   Subject,
-  switchMap,
   takeUntil
 } from 'rxjs';
 
@@ -15,14 +15,15 @@ import {
 import {
   CustomerBankModel,
   CustomersService,
-  IdentityVerificationBankModel,
-  PostIdentityVerificationBankModel,
   IdentityVerificationsService,
-  IdentityVerificationWithDetailsBankModel
+  IdentityVerificationWithDetailsBankModel,
+  PostIdentityVerificationBankModel
 } from '@cybrid/cybrid-api-bank-angular';
 
 // Services
 import { ConfigService } from '../config/config.service';
+import { CODE, EventService, LEVEL } from '../event/event.service';
+import { ErrorService } from '../error/error.service';
 
 @Injectable({
   providedIn: 'root'
@@ -43,7 +44,9 @@ export class IdentityVerificationService implements OnDestroy {
     private http: HttpClient,
     private identityVerificationService: IdentityVerificationsService,
     private customerService: CustomersService,
-    private configService: ConfigService
+    private configService: ConfigService,
+    private eventService: EventService,
+    private errorService: ErrorService
   ) {
     this.getCustomerGuid();
   }
@@ -71,46 +74,38 @@ export class IdentityVerificationService implements OnDestroy {
     return this.customerService.getCustomer(this.customerGuid);
   }
 
-  createIdentityVerification(): Observable<IdentityVerificationBankModel> {
-    return this.identityVerificationService.createIdentityVerification(
-      this.postIdentityVerificationBankModel
-    );
-  }
-
-  getIdentityVerification(): Observable<IdentityVerificationWithDetailsBankModel> {
+  createIdentityVerification(): Observable<IdentityVerificationWithDetailsBankModel> {
     return this.identityVerificationService
-      .listIdentityVerifications(
-        '0',
-        '1',
-        undefined,
-        undefined,
-        this.customerGuid
-      )
+      .createIdentityVerification(this.postIdentityVerificationBankModel)
       .pipe(
-        switchMap((list) => {
-          const identity = list.objects[0];
-          return identity
-            ? this.handleIdentityVerificationState(identity)
-            : this.createIdentityVerification();
+        catchError((err) => {
+          this.eventService.handleEvent(
+            LEVEL.ERROR,
+            CODE.DATA_ERROR,
+            'There was an error creating an identity verification',
+            err
+          );
+          this.errorService.handleError(err);
+          return of(err);
         })
       );
   }
 
-  handleIdentityVerificationState(
-    identity: IdentityVerificationBankModel
+  getIdentityVerification(
+    guid: string
   ): Observable<IdentityVerificationWithDetailsBankModel> {
-    return this.identityVerificationService
-      .getIdentityVerification(identity.guid!)
-      .pipe(
-        switchMap((identity) => {
-          if (
-            identity.state == 'expired' ||
-            identity.persona_state == 'expired'
-          ) {
-            return this.createIdentityVerification();
-          } else return of(identity);
-        })
-      );
+    return this.identityVerificationService.getIdentityVerification(guid).pipe(
+      catchError((err) => {
+        this.eventService.handleEvent(
+          LEVEL.ERROR,
+          CODE.DATA_ERROR,
+          'There was an error fetching the identity verification',
+          err
+        );
+        this.errorService.handleError(err);
+        return of(err);
+      })
+    );
   }
 
   setPersonaClient(client: any): void {

--- a/library/src/shared/services/identity-verification/identity-verification.service.ts
+++ b/library/src/shared/services/identity-verification/identity-verification.service.ts
@@ -107,12 +107,4 @@ export class IdentityVerificationService implements OnDestroy {
       })
     );
   }
-
-  setPersonaClient(client: any): void {
-    this.personaClient.next(client);
-  }
-
-  getPersonaClient(): Observable<any> {
-    return this.personaClient.asObservable();
-  }
 }


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [X] Bug fix

### Linked issue
- [X] Not tracked

### Why
The IDV component is fetching the most recently created IDV. We would like to create a new IDV upon component initialization.

### How
- Added always create functionality
- Ensured the in memory Persona SDK `inquiryId` is cleared on cancel
- Updated the JS Persona client version.

Upon Persona success the component checks the previously created IDV for `outcome`, and if the polling duration is reached before the `outcome` exists it pushes the IDV to the UI resulting in the "check back later" message.