### PR TITLE
fix: account details defaulting fiat currency

### DIFF
--- a/library/src/app/components/account/account-details/account-details.component.spec.ts
+++ b/library/src/app/components/account/account-details/account-details.component.spec.ts
@@ -45,6 +45,7 @@ describe('AccountDetailComponent', () => {
   let MockConfigService = jasmine.createSpyObj('ConfigService', [
     'setConfig',
     'getConfig$',
+    'getBank$',
     'getComponent$'
   ]);
   let MockQueryParams = of({
@@ -100,6 +101,9 @@ describe('AccountDetailComponent', () => {
     MockErrorService = TestBed.inject(ErrorService);
     MockConfigService = TestBed.inject(ConfigService);
     MockConfigService.getConfig$.and.returnValue(of(TestConstants.CONFIG));
+    MockConfigService.getBank$.and.returnValue(
+      of(TestConstants.BANK_BANK_MODEL)
+    );
     MockAssetService = TestBed.inject(AssetService);
     MockAssetService.getAsset.and.returnValue(TestConstants.USD_ASSET);
     MockTradesService = TestBed.inject(TradesService);

--- a/library/src/app/components/account/account-details/account-details.component.ts
+++ b/library/src/app/components/account/account-details/account-details.component.ts
@@ -131,12 +131,10 @@ export class AccountDetailsComponent
       .subscribe();
 
     this.configService
-      .getConfig$()
+      .getBank$()
       .pipe(
-        map((config) => {
-          this.counterAssetCode = config.fiat;
-          return config.fiat;
-        }),
+        take(1),
+        map((bank) => bank.supported_fiat_account_assets![0]),
         switchMap((counterAsset) => {
           return this.accountService
             .getAccountDetails(this.accountGuid, counterAsset)
@@ -232,6 +230,7 @@ export class AccountDetailsComponent
     this.configService
       .getConfig$()
       .pipe(
+        take(1),
         switchMap((cfg: ComponentConfig) => {
           return timer(cfg.refreshInterval, cfg.refreshInterval);
         }),

--- a/library/src/shared/constants/constants.ts
+++ b/library/src/shared/constants/constants.ts
@@ -52,7 +52,7 @@ export class Constants {
     theme: Constants.THEME,
     routing: Constants.ROUTING,
     customer: '',
-    fiat: 'USD',
+    fiat: '',
     environment: 'demo'
   };
   static DEFAULT_COMPONENT = 'price-list';

--- a/library/src/shared/constants/test.constants.ts
+++ b/library/src/shared/constants/test.constants.ts
@@ -39,7 +39,7 @@ export class TestConstants {
     theme: 'LIGHT',
     routing: true,
     customer: '378c691c1b5ba3b938e17c1726202fe4',
-    fiat: 'USD',
+    fiat: '',
     environment: 'demo'
   };
 


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [X] Bug fix

### Linked issue
- [X] Not tracked

### Why
The SDK is currently setting a default currency of USD in the published web demo. This causes the account-details component to fail when dealing with CAD accounts.

### How
Temporary fix sets the fiat asset as the first in the array of supported fiat currencies. A future fix should include a select that allows dependant components to swap between a banks multiple fiat currencies, and is only displayed if there are more than one.