### PR TITLE
chore: update circleci publish job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,7 @@ workflows:
 
       - publish:
           requires:
+            - test
             - e2e chromium@101.0.4951.64
             - e2e chromium@102.0.5005.61
             - e2e chrome@latest


### PR DESCRIPTION
### Type of change

- [X] Chore
- [ ] Feature
- [ ] Bug fix

### Linked issue
- [X] Not tracked

### Why
CircleCi successful `test` job is not a requirement for the `publish` job

### How
Added `test` to the `requires` array for  `publish`