### PR TITLE
fix: cypress IDV component POST mocks

### DIFF
--- a/cypress/e2e/identity-verification.cy.ts
+++ b/cypress/e2e/identity-verification.cy.ts
@@ -17,10 +17,15 @@ function identityVerificationSetup() {
 
 describe('identity-verification test', () => {
   beforeEach(() => {
+    cy.intercept('GET', 'api/prices*', (req) => {
+      req.reply(TestConstants.SYMBOL_PRICE_BANK_MODEL_ARRAY);
+    }).as('listPrices');
+    cy.intercept('GET', 'api/assets', (req) => {
+      req.reply(TestConstants.ASSET_LIST_BANK_MODEL);
+    }).as('listAssets');
     cy.intercept('GET', 'api/customers/*', (req) => {
       req.reply(TestConstants.CUSTOMER_BANK_MODEL);
     }).as('getCustomer');
-
     cy.intercept('GET', 'api/banks/*', (req) => {
       req.reply(TestConstants.BANK_BANK_MODEL);
     }).as('getBank');
@@ -105,22 +110,18 @@ describe('identity-verification test', () => {
       req.reply(customer);
     }).as('getCustomer');
 
-    //Mock identity list
-    const identityList = {
-      ...TestConstants.IDENTITY_VERIFICATION_LIST_BANK_MODEL
+    //Mock identity verification
+    const identityVerification = {
+      ...TestConstants.IDENTITY_VERIFICATION_BANK_MODEL
     };
-    identityList.objects[0].state = 'storing';
+    identityVerification.state = 'storing'
 
-    cy.intercept('GET', 'api/identity_verifications*', (req) => {
-      req.reply(identityList);
-    }).as('getIdentity');
-
-    //Mock identity
-    const identity = { ...TestConstants.IDENTITY_VERIFICATION_BANK_MODEL };
-    identity.persona_state = 'reviewing';
+    cy.intercept('POST', 'api/identity_verifications*', (req) => {
+      req.reply(identityVerification);
+    });
 
     cy.intercept('GET', 'api/identity_verifications/*', (req) => {
-      req.reply(identity);
+      req.reply(identityVerification);
     });
 
     cy.wait('@getCustomer').then(() => {
@@ -140,9 +141,17 @@ describe('identity-verification test', () => {
     //Mock customer
     const customer = { ...TestConstants.CUSTOMER_BANK_MODEL };
     customer.state = 'unverified';
+
     cy.intercept('GET', 'api/customers/*', (req) => {
       req.reply(customer);
     }).as('getCustomer');
+
+    //Mock identity verification
+    const identityVerification = {
+      ...TestConstants.IDENTITY_VERIFICATION_BANK_MODEL
+    };
+    identityVerification.state = 'completed';
+    identityVerification.persona_state = 'reviewing';
 
     //Mock list identity
     const identityList = {
@@ -150,16 +159,12 @@ describe('identity-verification test', () => {
     };
     identityList.objects[0].state = 'completed';
 
-    //Mock identity
-    const identity = { ...TestConstants.IDENTITY_VERIFICATION_BANK_MODEL };
-    identity.persona_state = 'reviewing';
-
-    cy.intercept('GET', 'api/identity_verifications*', (req) => {
-      req.reply(identityList);
+    cy.intercept('POST', 'api/identity_verifications*', (req) => {
+      req.reply(identityVerification);
     });
 
     cy.intercept('GET', 'api/identity_verifications/*', (req) => {
-      req.reply(identity);
+      req.reply(identityVerification);
     });
 
     cy.wait('@getCustomer').then(() => {
@@ -184,18 +189,13 @@ describe('identity-verification test', () => {
       req.reply(customer);
     }).as('getCustomer');
 
-    //Mock list identity
-    const identityList = {
-      ...TestConstants.IDENTITY_VERIFICATION_LIST_BANK_MODEL
-    };
-    identityList.objects[0].state = 'waiting';
-
-    //Mock identity
+    //Mock identity verification
     const identity = { ...TestConstants.IDENTITY_VERIFICATION_BANK_MODEL };
+    identity.state = 'waiting';
     identity.persona_state = 'processing';
 
-    cy.intercept('GET', 'api/identity_verifications*', (req) => {
-      req.reply(identityList);
+    cy.intercept('POST', 'api/identity_verifications*', (req) => {
+      req.reply(identity);
     });
 
     cy.intercept('GET', 'api/identity_verifications/*', (req) => {
@@ -220,21 +220,31 @@ describe('identity-verification test', () => {
     //Mock customer
     const customer = { ...TestConstants.CUSTOMER_BANK_MODEL };
     customer.state = 'unverified';
+
     cy.intercept('GET', 'api/customers/*', (req) => {
       req.reply(customer);
     }).as('getCustomer');
 
-    //Mock list identity
-    const identity = { ...TestConstants.IDENTITY_VERIFICATION_LIST_BANK_MODEL };
-    identity.objects[0].state = 'completed';
-    identity.objects[0].outcome = 'passed';
+    //Mock identity verification
+    const identityVerification = {
+      ...TestConstants.IDENTITY_VERIFICATION_BANK_MODEL
+    };
+    identityVerification.state = 'completed';
+    identityVerification.outcome = 'passed';
 
-    cy.intercept('GET', 'api/identity_verifications*', (req) => {
-      req.reply(identity);
-    }).as('getIdentity');
+    //Mock list identity
+    const identityList = {
+      ...TestConstants.IDENTITY_VERIFICATION_LIST_BANK_MODEL
+    };
+    identityList.objects[0].state = 'completed';
+    identityList.objects[0].outcome = 'passed';
+
+    cy.intercept('POST', 'api/identity_verifications*', (req) => {
+      req.reply(identityVerification);
+    });
 
     cy.intercept('GET', 'api/identity_verifications/*', (req) => {
-      req.reply(identity.objects[0]);
+      req.reply(identityVerification);
     });
 
     cy.wait('@getCustomer').then(() => {
@@ -259,6 +269,13 @@ describe('identity-verification test', () => {
       req.reply(customer);
     }).as('getCustomer');
 
+    //Mock identity verification
+    const identityVerification = {
+      ...TestConstants.IDENTITY_VERIFICATION_BANK_MODEL
+    };
+    identityVerification.state = 'completed';
+    identityVerification.outcome = 'failed';
+
     //Mock list identity
     const identityList = {
       ...TestConstants.IDENTITY_VERIFICATION_LIST_BANK_MODEL
@@ -266,16 +283,12 @@ describe('identity-verification test', () => {
     identityList.objects[0].state = 'completed';
     identityList.objects[0].outcome = 'failed';
 
-    cy.intercept('GET', 'api/identity_verifications*', (req) => {
-      req.reply(identityList);
-    }).as('getIdentity');
-
-    // Mock identity
-    const identity = { ...TestConstants.IDENTITY_VERIFICATION_BANK_MODEL };
-    identity.persona_state = 'completed';
+    cy.intercept('POST', 'api/identity_verifications*', (req) => {
+      req.reply(identityVerification);
+    });
 
     cy.intercept('GET', 'api/identity_verifications/*', (req) => {
-      req.reply(identity);
+      req.reply(identityVerification);
     });
 
     cy.wait('@getCustomer').then(() => {

--- a/cypress/e2e/identity-verification.cy.ts
+++ b/cypress/e2e/identity-verification.cy.ts
@@ -40,6 +40,7 @@ describe('identity-verification test', () => {
     // Mock customer
     const customer = { ...TestConstants.CUSTOMER_BANK_MODEL };
     customer.state = 'storing';
+
     cy.intercept('GET', 'api/customers/*', (req) => {
       delete req.headers['if-none-match'];
       req.reply(customer);
@@ -61,6 +62,7 @@ describe('identity-verification test', () => {
     //Mock customer
     const customer = { ...TestConstants.CUSTOMER_BANK_MODEL };
     customer.state = 'verified';
+
     cy.intercept('GET', 'api/customers/*', (req) => {
       delete req.headers['if-none-match'];
       req.reply(customer);
@@ -83,6 +85,7 @@ describe('identity-verification test', () => {
     //Mock customer
     const customer = { ...TestConstants.CUSTOMER_BANK_MODEL };
     customer.state = 'rejected';
+
     cy.intercept('GET', 'api/customers/*', (req) => {
       delete req.headers['if-none-match'];
       req.reply(customer);
@@ -105,6 +108,7 @@ describe('identity-verification test', () => {
     //Mock customer
     const customer = { ...TestConstants.CUSTOMER_BANK_MODEL };
     customer.state = 'unverified';
+
     cy.intercept('GET', 'api/customers/*', (req) => {
       delete req.headers['if-none-match'];
       req.reply(customer);
@@ -153,12 +157,6 @@ describe('identity-verification test', () => {
     identityVerification.state = 'completed';
     identityVerification.persona_state = 'reviewing';
 
-    //Mock list identity
-    const identityList = {
-      ...TestConstants.IDENTITY_VERIFICATION_LIST_BANK_MODEL
-    };
-    identityList.objects[0].state = 'completed';
-
     cy.intercept('POST', 'api/identity_verifications*', (req) => {
       req.reply(identityVerification);
     });
@@ -185,21 +183,22 @@ describe('identity-verification test', () => {
     //Mock customer
     const customer = { ...TestConstants.CUSTOMER_BANK_MODEL };
     customer.state = 'unverified';
+
     cy.intercept('GET', 'api/customers/*', (req) => {
       req.reply(customer);
     }).as('getCustomer');
 
     //Mock identity verification
-    const identity = { ...TestConstants.IDENTITY_VERIFICATION_BANK_MODEL };
-    identity.state = 'waiting';
-    identity.persona_state = 'processing';
+    const identityVerification = { ...TestConstants.IDENTITY_VERIFICATION_BANK_MODEL };
+    identityVerification.state = 'waiting';
+    identityVerification.persona_state = 'processing';
 
     cy.intercept('POST', 'api/identity_verifications*', (req) => {
-      req.reply(identity);
+      req.reply(identityVerification);
     });
 
     cy.intercept('GET', 'api/identity_verifications/*', (req) => {
-      req.reply(identity);
+      req.reply(identityVerification);
     });
 
     cy.wait('@getCustomer').then(() => {
@@ -232,13 +231,6 @@ describe('identity-verification test', () => {
     identityVerification.state = 'completed';
     identityVerification.outcome = 'passed';
 
-    //Mock list identity
-    const identityList = {
-      ...TestConstants.IDENTITY_VERIFICATION_LIST_BANK_MODEL
-    };
-    identityList.objects[0].state = 'completed';
-    identityList.objects[0].outcome = 'passed';
-
     cy.intercept('POST', 'api/identity_verifications*', (req) => {
       req.reply(identityVerification);
     });
@@ -265,6 +257,7 @@ describe('identity-verification test', () => {
     //Mock customer
     const customer = { ...TestConstants.CUSTOMER_BANK_MODEL };
     customer.state = 'unverified';
+
     cy.intercept('GET', 'api/customers/*', (req) => {
       req.reply(customer);
     }).as('getCustomer');
@@ -275,13 +268,6 @@ describe('identity-verification test', () => {
     };
     identityVerification.state = 'completed';
     identityVerification.outcome = 'failed';
-
-    //Mock list identity
-    const identityList = {
-      ...TestConstants.IDENTITY_VERIFICATION_LIST_BANK_MODEL
-    };
-    identityList.objects[0].state = 'completed';
-    identityList.objects[0].outcome = 'failed';
 
     cy.intercept('POST', 'api/identity_verifications*', (req) => {
       req.reply(identityVerification);

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -13,7 +13,7 @@ function customCommand(param: any): void {
   console.warn(param);
 }
 
-before(() => {
+beforeEach(() => {
   cy.intercept(
     'GET',
     'https://api.github.com/repos/Cybrid-app/cybrid-sdk-web/releases/latest',


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [X] Bug fix

### Linked issue
- [X] Not tracked

### Why
IDV e2e is unnecessarily spamming POST calls to the `identity_verifications` api

### How
Refactored to mock calls