### PR TITLE
feat: patch external bank account in update mode

### DIFF
--- a/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.spec.ts
+++ b/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.spec.ts
@@ -52,7 +52,8 @@ describe('BankAccountConnectComponent', () => {
     'getWorkflow',
     'getPlaidClient',
     'setPlaidClient',
-    'createExternalBankAccount'
+    'createExternalBankAccount',
+    'patchExternalBankAccount'
   ]);
   let MockDialog = jasmine.createSpyObj('Dialog', ['open']);
   const error$ = throwError(() => {
@@ -96,6 +97,9 @@ describe('BankAccountConnectComponent', () => {
     );
     MockBankAccountService.getWorkflow.and.returnValue(
       of(TestConstants.WORKFLOW_BANK_MODEL_WITH_DETAILS)
+    );
+    MockBankAccountService.patchExternalBankAccount.and.returnValue(
+      of(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL)
     );
     MockBankAccountService.createExternalBankAccount.and.returnValue(
       of(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL)
@@ -297,6 +301,18 @@ describe('BankAccountConnectComponent', () => {
       accounts: [{ name: '', id: '', iso_currency_code: undefined }]
     });
     expect(getCurrencyCodeSpy).toHaveBeenCalled();
+  });
+
+  it('should handle plaidOnSuccess() in update mode', () => {
+    // Define an external account guid to trigger update mode
+    // @ts-ignore
+    component.params = '';
+
+    component.plaidOnSuccess('', {
+      accounts: [{ name: '', id: '', iso_currency_code: 'USD' }]
+    });
+
+    expect(MockBankAccountService.patchExternalBankAccount).toHaveBeenCalled();
   });
 
   it('should handle getCurrencyCode() returning undefined', () => {

--- a/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.ts
+++ b/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.ts
@@ -24,7 +24,6 @@ import {
 import {
   BankBankModel,
   CustomersService,
-  ExternalBankAccountBankModel,
   PostWorkflowBankModel,
   WorkflowsService,
   WorkflowWithDetailsBankModel
@@ -267,8 +266,17 @@ export class BankAccountConnectComponent implements OnInit {
   }
 
   plaidOnSuccess(public_token: string, metadata?: any) {
-    if (this.params) {
-      this.isLoading$.next(false);
+    if (this.params != null) {
+      this.bankAccountService
+        .patchExternalBankAccount(<string>this.params)
+        .pipe(
+          map(() => this.isLoading$.next(false)),
+          catchError((err) => {
+            this.error$.next(true);
+            return of(err);
+          })
+        )
+        .subscribe();
     } else if (!this.params && metadata.accounts.length > 1) {
       this.error$.next(true);
       this.eventService.handleEvent(

--- a/library/src/shared/services/bank-account/bank-account.service.spec.ts
+++ b/library/src/shared/services/bank-account/bank-account.service.spec.ts
@@ -37,6 +37,7 @@ describe('BankAccountManagementService', () => {
     [
       'listExternalBankAccounts',
       'createExternalBankAccount',
+      'patchExternalBankAccount',
       'deleteExternalBankAccount'
     ]
   );
@@ -84,6 +85,9 @@ describe('BankAccountManagementService', () => {
     MockExternalBankAccountService.createExternalBankAccount.and.returnValue(
       of(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL)
     );
+    MockExternalBankAccountService.patchExternalBankAccount.and.returnValue(
+      of(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL)
+    );
     MockExternalBankAccountService.deleteExternalBankAccount.and.returnValue(
       of(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL)
     );
@@ -101,6 +105,9 @@ describe('BankAccountManagementService', () => {
       of(TestConstants.EXTERNAL_BANK_ACCOUNT_LIST_BANK_MODEL)
     );
     MockExternalBankAccountService.createExternalBankAccount.and.returnValue(
+      of(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL)
+    );
+    MockExternalBankAccountService.patchExternalBankAccount.and.returnValue(
       of(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL)
     );
     MockExternalBankAccountService.deleteExternalBankAccount.and.returnValue(
@@ -172,6 +179,23 @@ describe('BankAccountManagementService', () => {
           MockExternalBankAccountService.createExternalBankAccount
         ).toHaveBeenCalledWith(postExternalBankAccountModel)
       );
+  });
+
+  it('should patch an external bank account', () => {
+    service.patchExternalBankAccount('').subscribe();
+    expect(
+      MockExternalBankAccountService.patchExternalBankAccount
+    ).toHaveBeenCalled();
+  });
+
+  it('should catch any errors on patchExternalBankAccount()', () => {
+    MockExternalBankAccountService.patchExternalBankAccount.and.returnValue(
+      error$
+    );
+
+    service.patchExternalBankAccount('').subscribe();
+    expect(MockErrorService.handleError).toHaveBeenCalled();
+    expect(MockEventService.handleEvent).toHaveBeenCalled();
   });
 
   it('should delete an external bank account', () => {

--- a/library/src/shared/services/bank-account/bank-account.service.ts
+++ b/library/src/shared/services/bank-account/bank-account.service.ts
@@ -24,6 +24,7 @@ import {
   ExternalBankAccountBankModel,
   ExternalBankAccountListBankModel,
   ExternalBankAccountsService,
+  PatchExternalBankAccountBankModel,
   PostExternalBankAccountBankModel,
   PostWorkflowBankModel,
   WorkflowBankModel,
@@ -134,6 +135,31 @@ export class BankAccountService implements OnDestroy {
           const message = 'There was an error creating a bank account';
           this.eventService.handleEvent(LEVEL.ERROR, CODE.DATA_ERROR, message);
           this.errorService.handleError(err);
+          return of(err);
+        })
+      );
+  }
+
+  patchExternalBankAccount(
+    externalAccountGuid: string
+  ): Observable<ExternalBankAccountBankModel> {
+    const patchExternalBankAccountModel: PatchExternalBankAccountBankModel = {
+      state: PatchExternalBankAccountBankModel.StateEnum.Completed
+    };
+
+    return this.externalBankAccountService
+      .patchExternalBankAccount(
+        externalAccountGuid,
+        patchExternalBankAccountModel
+      )
+      .pipe(
+        catchError((err) => {
+          this.eventService.handleEvent(
+            LEVEL.ERROR,
+            CODE.DATA_ERROR,
+            'Unable to update account'
+          );
+          this.errorService.handleError(new Error('Unable to update account'));
           return of(err);
         })
       );

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -21,5 +21,5 @@ export const environment = {
   grant_type: 'client_credentials',
   credentials: ci.environment.credentials,
   scope:
-    'banks:read banks:write accounts:read accounts:execute customers:read customers:write customers:execute prices:read quotes:execute trades:execute trades:read external_bank_accounts:read external_bank_accounts:execute workflows:read workflows:execute transfers:read transfers:execute'
+    'banks:read banks:write accounts:read accounts:execute customers:read customers:write customers:execute prices:read quotes:execute trades:execute trades:read external_bank_accounts:read external_bank_accounts:execute external_bank_accounts:write workflows:read workflows:execute transfers:read transfers:execute'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -30,5 +30,5 @@ export const environment = {
   },
   grant_type: 'client_credentials',
   scope:
-    'banks:read banks:write accounts:read accounts:execute customers:read customers:write customers:execute prices:read quotes:execute trades:execute trades:read external_bank_accounts:read external_bank_accounts:execute workflows:read workflows:execute transfers:read transfers:execute'
+    'banks:read banks:write accounts:read accounts:execute customers:read customers:write customers:execute prices:read quotes:execute trades:execute trades:read external_bank_accounts:read external_bank_accounts:execute external_bank_accounts:write workflows:read workflows:execute transfers:read transfers:execute'
 };


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [x] Feature
- [ ] Bug fix

### Linked issue
- [X] Not tracked

### Why
When an external bank account has been reconnected successfully we need to patch the internal account state from `refresh_required` to `connected`

### How
By adding the api call to the `bank-account-connect` component when the update flow receives a Plaid `onSuccess` callback