### PR TITLE
chore: update cypress base docker tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ workflows:
                   apt update -y
                   apt-get install -y wget
                   apt-get install -y unzip
-                  apt-get install ca-certificates
+                  apt-get install -y ca-certificates
             - run:
                 name: Download/Install Chromium
                 command: |
@@ -127,7 +127,7 @@ workflows:
                   apt update -y
                   apt-get install -y wget
                   apt-get install -y unzip
-                  apt-get install ca-certificates
+                  apt-get install -y ca-certificates
             - run:
                 name: Download/Install Chromium
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ orbs:
 executors:
   cypress:
     docker:
-      - image: cypress/base:18.12.1
+      - image: cypress/base:18.15.0
 
 jobs:
   publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ workflows:
       - check-versions
       - node/test:
           name: test
-          version: 16.14.2-browsers
+          version: 16.20.0-browsers
           cache-version: v2
           setup:
             - browser-tools/install-chrome

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,7 @@ workflows:
                   apt update -y
                   apt-get install -y wget
                   apt-get install -y unzip
+                  apt-get install ca-certificates
             - run:
                 name: Download/Install Chromium
                 command: |
@@ -126,6 +127,7 @@ workflows:
                   apt update -y
                   apt-get install -y wget
                   apt-get install -y unzip
+                  apt-get install ca-certificates
             - run:
                 name: Download/Install Chromium
                 command: |


### PR DESCRIPTION
### Type of change

- [x] Chore
- [ ] Feature
- [ ] Bug fix

### Linked issue
- [x] Not tracked

### Why
New docker image fails to download Chrome 101 and 102 for testing due to wget not trusting certificates

### How
Added `apt-get install ca-certificates` to manually update certs