### PR TITLE
feat: remove sdk dependency on scope `banks: read`

### DIFF
--- a/cypress/e2e/bank-account-connect.cy.ts
+++ b/cypress/e2e/bank-account-connect.cy.ts
@@ -162,7 +162,7 @@ describe('bank-account-connect test', () => {
     cy.get('h1').should('contain.text', text.bankAccountConnect.confirm.title);
     cy.get('p')
       .first()
-      .should('contain.text', text.bankAccountConnect.confirm.subtitle);
+      .should('contain.text', text.bankAccountConnect.confirm.message);
 
     // Cancel
     cy.get('mat-dialog-container').contains(text.cancel).click();

--- a/library/README.md
+++ b/library/README.md
@@ -37,7 +37,11 @@ The script registers `cybrid-app` as a web-component in your window.
     <script type="module" src="cybrid-sdk-ui.min.js"></script>
   </head>
   <body>
-    <cybrid-app [auth]="token" [config]="config" [component]="component" ></cybrid-app>
+    <cybrid-app
+      [auth]="token"
+      [config]="config"
+      [component]="component"
+    ></cybrid-app>
   </body>
 </html>
 ```
@@ -109,12 +113,17 @@ interface ComponentConfig {
 
   // The current customer GUID
   customer: string;
-  
+
   // The current fiat currency (counter asset for all value calculation)
   // Supports: 'USD | CAD'
   // Default: 'USD'
   fiat: string;
-  
+
+  // The banks features
+  // Supports: 'attestation_identity_records' | 'kyc_identity_verifications' | 'backstopped_funding_source' | 'plaid_funding_source'
+  // Default: []
+  features: Array<string>;
+
   // The environment that you are authenticated against
   // Supports: 'sandbox' | 'production'
   environment: string;
@@ -133,6 +142,7 @@ your_config = {
   theme: 'DARK',
   customer: '969c744a02b11ed', //example GUID,
   fiat: 'USD',
+  features: ['attestation_identity_records', 'backstopped_funding_source'],
   environment: 'sandbox'
 };
 ```

--- a/library/src/app/components/account/account-details/account-details.component.spec.ts
+++ b/library/src/app/components/account/account-details/account-details.component.spec.ts
@@ -45,7 +45,6 @@ describe('AccountDetailComponent', () => {
   let MockConfigService = jasmine.createSpyObj('ConfigService', [
     'setConfig',
     'getConfig$',
-    'getBank$',
     'getComponent$'
   ]);
   let MockQueryParams = of({
@@ -101,9 +100,6 @@ describe('AccountDetailComponent', () => {
     MockErrorService = TestBed.inject(ErrorService);
     MockConfigService = TestBed.inject(ConfigService);
     MockConfigService.getConfig$.and.returnValue(of(TestConstants.CONFIG));
-    MockConfigService.getBank$.and.returnValue(
-      of(TestConstants.BANK_BANK_MODEL)
-    );
     MockAssetService = TestBed.inject(AssetService);
     MockAssetService.getAsset.and.returnValue(TestConstants.USD_ASSET);
     MockTradesService = TestBed.inject(TradesService);

--- a/library/src/app/components/account/account-details/account-details.component.ts
+++ b/library/src/app/components/account/account-details/account-details.component.ts
@@ -131,10 +131,10 @@ export class AccountDetailsComponent
       .subscribe();
 
     this.configService
-      .getBank$()
+      .getConfig$()
       .pipe(
         take(1),
-        map((bank) => bank.supported_fiat_account_assets![0]),
+        map((config) => config.fiat),
         switchMap((counterAsset) => {
           return this.accountService
             .getAccountDetails(this.accountGuid, counterAsset)

--- a/library/src/app/components/app/app.component.spec.ts
+++ b/library/src/app/components/app/app.component.spec.ts
@@ -54,7 +54,6 @@ describe('AppComponent', () => {
     'setConfig',
     'getConfig$',
     'getCustomer$',
-    'getBank$',
     'setComponent'
   ]);
   let MockRoutingService = jasmine.createSpyObj('RoutingService', [
@@ -97,9 +96,6 @@ describe('AppComponent', () => {
     MockConfigService = TestBed.inject(ConfigService);
     MockConfigService.getCustomer$.and.returnValue(
       of(TestConstants.CUSTOMER_BANK_MODEL)
-    );
-    MockConfigService.getBank$.and.returnValue(
-      of(TestConstants.BANK_BANK_MODEL)
     );
     MockRouter = TestBed.inject(Router);
     MockRouter.navigate.and.returnValue(Promise.resolve(true));

--- a/library/src/app/components/app/app.component.ts
+++ b/library/src/app/components/app/app.component.ts
@@ -81,7 +81,6 @@ export class AppComponent implements OnInit {
     combineLatest([
       this.configService.getConfig$(),
       this.configService.getCustomer$(),
-      this.configService.getBank$(),
       this.assetService.getAssets$()
     ])
       .pipe(

--- a/library/src/app/components/bank-account-management/bank-account-confirm/bank-account-confirm.component.html
+++ b/library/src/app/components/bank-account-management/bank-account-confirm/bank-account-confirm.component.html
@@ -1,33 +1,22 @@
 <ng-container *ngIf="(isLoading$ | async) !== true; else loading">
-  <h1>{{ 'bankAccountConnect.confirm.title' | translate }}</h1>
-  <p>{{ 'bankAccountConnect.confirm.subtitle' | translate }}</p>
-  <ng-container [formGroup]="assetGroup">
-    <div class="cybrid-input-wrapper">
-      <label class="mat-hint cybrid-h5">{{
-        'bankAccountConnect.confirm.label' | translate
-      }}</label>
-      <mat-form-field appearance="outline">
-        <mat-select #asset formControlName="asset">
-          <mat-option *ngFor="let asset of assets" [value]="asset">
-            {{ asset }}
-          </mat-option>
-        </mat-select>
-      </mat-form-field>
-    </div>
-    <div class="cybrid-actions">
-      <button id="'cancel" mat-flat-button [mat-dialog-close]>
-        {{ 'cancel' | translate }}
-      </button>
-      <button
-        id="confirm"
-        mat-flat-button
-        color="primary"
-        (click)="onConfirm()"
-      >
-        {{ 'confirm' | translate }}
-      </button>
-    </div>
-  </ng-container>
+  <h1 class="mat-dialog-title">
+    {{ 'bankAccountConnect.confirm.title' | translate }}
+  </h1>
+  <div class="mat-dialog-content">
+    <p>
+      {{ 'bankAccountConnect.confirm.message' | translate }}
+      <strong>{{ code }}</strong
+      >?
+    </p>
+  </div>
+  <div mat-dialog-actions align="end">
+    <button id="'cancel" mat-flat-button [mat-dialog-close]>
+      {{ 'cancel' | translate }}
+    </button>
+    <button id="confirm" mat-flat-button color="primary" (click)="onConfirm()">
+      {{ 'confirm' | translate }}
+    </button>
+  </div>
 </ng-container>
 <ng-template #loading>
   <app-loading></app-loading>

--- a/library/src/app/components/bank-account-management/bank-account-confirm/bank-account-confirm.component.spec.ts
+++ b/library/src/app/components/bank-account-management/bank-account-confirm/bank-account-confirm.component.spec.ts
@@ -12,14 +12,12 @@ import { BankAccountConfirmComponent } from '@components';
 // Utility
 import { TestConstants } from '@constants';
 import { SharedModule } from '../../../../shared/modules/shared.module';
-import { BankBankModel } from '@cybrid/cybrid-api-bank-angular';
 
 describe('BankAccountConfirmComponent', () => {
   let component: BankAccountConfirmComponent;
   let fixture: ComponentFixture<BankAccountConfirmComponent>;
 
   let MockDialog = jasmine.createSpyObj('Dialog', ['open', 'close']);
-  let MockBank: BankBankModel = TestConstants.BANK_BANK_MODEL;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -40,7 +38,7 @@ describe('BankAccountConfirmComponent', () => {
         { provide: MatDialogRef, useValue: MockDialog },
         {
           provide: MAT_DIALOG_DATA,
-          useValue: MockBank
+          useValue: TestConstants.CONFIG.fiat
         }
       ]
     }).compileComponents();
@@ -54,14 +52,6 @@ describe('BankAccountConfirmComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should initialize the asset group', () => {
-    const isLoadingSpy = spyOn(component.isLoading$, 'next');
-
-    component.initAssetGroup();
-    expect(component.assetGroup).toBeDefined();
-    expect(isLoadingSpy).toHaveBeenCalled();
-  });
-
   it('should close the dialog onCancel()', () => {
     component.onCancel();
     expect(MockDialog.close).toHaveBeenCalled();
@@ -73,10 +63,7 @@ describe('BankAccountConfirmComponent', () => {
   });
 
   it('should pass the selected currency code onConfirm()', () => {
-    component.initAssetGroup();
     component.onConfirm();
-    expect(MockDialog.close).toHaveBeenCalledWith(
-      component.assetGroup.value.asset
-    );
+    expect(MockDialog.close).toHaveBeenCalledWith(component.code);
   });
 });

--- a/library/src/app/components/bank-account-management/bank-account-confirm/bank-account-confirm.component.ts
+++ b/library/src/app/components/bank-account-management/bank-account-confirm/bank-account-confirm.component.ts
@@ -1,13 +1,10 @@
-import { Component, Inject, OnInit } from '@angular/core';
+import { Component, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { FormControl, FormGroup } from '@angular/forms';
 import { BehaviorSubject } from 'rxjs';
 
 // Services
 import { RoutingData } from '@services';
-
-// Client
-import { BankBankModel } from '@cybrid/cybrid-api-bank-angular';
 
 interface AssetGroup {
   asset: FormControl<string>;
@@ -18,11 +15,11 @@ interface AssetGroup {
   templateUrl: './bank-account-confirm.component.html',
   styleUrls: ['./bank-account-confirm.component.scss']
 })
-export class BankAccountConfirmComponent implements OnInit {
+export class BankAccountConfirmComponent {
   assetGroup!: FormGroup<AssetGroup>;
   assets!: Array<string>;
 
-  isLoading$ = new BehaviorSubject(true);
+  isLoading$ = new BehaviorSubject(false);
 
   routingData: RoutingData = {
     route: 'account-list',
@@ -30,31 +27,15 @@ export class BankAccountConfirmComponent implements OnInit {
   };
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public bank: BankBankModel,
+    @Inject(MAT_DIALOG_DATA) public code: string,
     public dialogRef: MatDialogRef<BankAccountConfirmComponent>
   ) {}
-
-  ngOnInit(): void {
-    this.initAssetGroup();
-  }
-
-  initAssetGroup() {
-    this.assets = this.bank.supported_fiat_account_assets!;
-
-    this.assetGroup = new FormGroup<AssetGroup>({
-      asset: new FormControl(this.assets[0], {
-        nonNullable: true
-      })
-    });
-
-    this.isLoading$.next(false);
-  }
 
   onCancel(): void {
     this.dialogRef.close();
   }
 
   onConfirm(): void {
-    this.dialogRef.close(this.assetGroup.value.asset);
+    this.dialogRef.close(this.code);
   }
 }

--- a/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.spec.ts
+++ b/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.spec.ts
@@ -41,7 +41,6 @@ describe('BankAccountConnectComponent', () => {
   ]);
   let MockConfigService = jasmine.createSpyObj('ConfigService', {
     getConfig$: of(TestConstants.CONFIG),
-    getBank$: of(TestConstants.BANK_BANK_MODEL),
     getCustomer$: of(TestConstants.CUSTOMER_BANK_MODEL)
   });
   let MockRoutingService = jasmine.createSpyObj('RoutingService', [
@@ -119,7 +118,6 @@ describe('BankAccountConnectComponent', () => {
     MockEventService.handleEvent.calls.reset();
     MockErrorService.handleError.calls.reset();
     MockConfigService.getConfig$.calls.reset();
-    MockConfigService.getBank$.calls.reset();
     MockConfigService.getCustomer$.calls.reset();
     MockRoutingService.handleRoute.calls.reset();
     MockBankAccountService.createWorkflow.calls.reset();
@@ -154,23 +152,22 @@ describe('BankAccountConnectComponent', () => {
     const onAddAccountSpy = spyOn(component, 'onAddAccount');
 
     component.checkSupportedFiatAssets();
-    expect(MockConfigService.getBank$).toHaveBeenCalled();
+
+    expect(MockConfigService.getConfig$).toHaveBeenCalled();
     expect(onAddAccountSpy).toHaveBeenCalled();
   });
 
   it('should handle no supported fiat assets', () => {
-    let bank = { ...TestConstants.BANK_BANK_MODEL };
-    bank.supported_fiat_account_assets = [];
-    MockConfigService.getBank$.and.returnValue(of(bank));
+    let config = { ...TestConstants.CONFIG };
+    config.fiat = '';
+    MockConfigService.getConfig$.and.returnValue(of(config));
 
     component.checkSupportedFiatAssets();
     expect(MockEventService.handleEvent).toHaveBeenCalled();
     expect(MockErrorService.handleError).toHaveBeenCalled();
 
     // Reset
-    MockConfigService.getBank$.and.returnValue(
-      of(TestConstants.BANK_BANK_MODEL)
-    );
+    MockConfigService.getConfig$.and.returnValue(of(TestConstants.CONFIG));
   });
 
   it('should add account', () => {
@@ -195,12 +192,10 @@ describe('BankAccountConnectComponent', () => {
   });
 
   it('should get the currency code', (done) => {
-    component
-      .getCurrencyCode(TestConstants.BANK_BANK_MODEL)
-      .subscribe((res) => {
-        expect(res).toEqual('USD');
-        done();
-      });
+    component.getCurrencyCode(TestConstants.CONFIG.fiat).subscribe((res) => {
+      expect(res).toEqual('USD');
+      done();
+    });
   });
 
   it('should create a workflow', (done) => {

--- a/library/src/shared/constants/constants.ts
+++ b/library/src/shared/constants/constants.ts
@@ -53,6 +53,7 @@ export class Constants {
     routing: Constants.ROUTING,
     customer: '',
     fiat: '',
+    features: [],
     environment: 'sandbox'
   };
   static DEFAULT_COMPONENT = 'price-list';
@@ -75,4 +76,23 @@ export class Constants {
     'account-details',
     'identity-verification'
   ];
+  static COMPONENTS_ATTESTATION = [
+    'price-list',
+    'trade',
+    'account-list',
+    'account-details',
+    'bank-account-connect',
+    'bank-account-list',
+    'transfer'
+  ];
+  static COMPONENTS_KYC = [
+    'price-list',
+    'trade',
+    'account-list',
+    'account-details',
+    'identity-verification',
+    'bank-account-connect',
+    'bank-account-list',
+    'transfer'
+  ]
 }

--- a/library/src/shared/constants/constants.ts
+++ b/library/src/shared/constants/constants.ts
@@ -94,5 +94,5 @@ export class Constants {
     'bank-account-connect',
     'bank-account-list',
     'transfer'
-  ]
+  ];
 }

--- a/library/src/shared/constants/test.constants.ts
+++ b/library/src/shared/constants/test.constants.ts
@@ -3,7 +3,6 @@ import {
   AccountBankModel,
   AccountListBankModel,
   AssetListBankModel,
-  BankBankModel,
   CustomerBankModel,
   ExternalBankAccountBankModel,
   ExternalBankAccountListBankModel,
@@ -39,7 +38,8 @@ export class TestConstants {
     theme: 'LIGHT',
     routing: true,
     customer: '`b283116f9f94742dcd1feda21cc0a8cb',
-    fiat: '',
+    fiat: 'USD',
+    features: ['attestation_identity_records', 'backstopped_funding_source'],
     environment: 'staging'
   };
 
@@ -603,20 +603,6 @@ export class TestConstants {
     type: 'plaid',
     created_at: '2022-11-10T21:05:13.932Z',
     plaid_link_token: 'link-sandbox-b46225aa-ec75-4de9-b8a7-7ed4c8630401'
-  };
-
-  // Bank models
-
-  static BANK_BANK_MODEL: BankBankModel = {
-    guid: 'b36cf9028e2356de7732e4c505c84fbc',
-    organization_guid: '62342aeb3c733f62a54fcd185f8a9253',
-    name: 'dustin',
-    supported_trading_symbols: ['BTC-USD', 'ETH-USD'],
-    supported_fiat_account_assets: ['USD'],
-    supported_country_codes: ['US'],
-    type: 'sandbox',
-    features: ['attestation_identity_records', 'backstopped_funding_source'],
-    created_at: '2022-04-30T03:40:54.629Z'
   };
 
   // Transfer models

--- a/library/src/shared/guards/component.guard.spec.ts
+++ b/library/src/shared/guards/component.guard.spec.ts
@@ -27,7 +27,7 @@ describe('ComponentGuard', () => {
     'getEvent',
     'handleEvent'
   ]);
-  let MockConfigService = jasmine.createSpyObj('ConfigService', ['getBank$']);
+  let MockConfigService = jasmine.createSpyObj('ConfigService', ['getConfig$']);
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -52,9 +52,7 @@ describe('ComponentGuard', () => {
     guard = TestBed.inject(ComponentGuard);
     MockEventService = TestBed.inject(EventService);
     MockConfigService = TestBed.inject(ConfigService);
-    MockConfigService.getBank$.and.returnValue(
-      of(TestConstants.BANK_BANK_MODEL)
-    );
+    MockConfigService.getConfig$.and.returnValue(of(TestConstants.CONFIG));
   });
 
   it('should be created', () => {
@@ -68,6 +66,10 @@ describe('ComponentGuard', () => {
 
     const mockRouterStateSnapshot: RouterStateSnapshot =
       {} as RouterStateSnapshot;
+
+    let config = TestConstants.CONFIG;
+    config.features = ['backstopped_funding_source'];
+    MockConfigService.getConfig$.and.returnValue(of(config));
 
     guard
       .canActivate(mockActivatedRouteSnapshot, mockRouterStateSnapshot)
@@ -83,6 +85,48 @@ describe('ComponentGuard', () => {
 
     const mockRouterStateSnapshot: RouterStateSnapshot =
       {} as RouterStateSnapshot;
+
+    let config = TestConstants.CONFIG;
+    config.features = ['backstopped_funding_source'];
+    MockConfigService.getConfig$.and.returnValue(of(config));
+
+    guard
+      .canActivate(mockActivatedRouteSnapshot, mockRouterStateSnapshot)
+      .subscribe((res) => {
+        expect(res).toBeFalse();
+      });
+  });
+
+  it('should pass allowed components in an attestation bank', () => {
+    const mockActivatedRouteSnapshot: ActivatedRouteSnapshot = {
+      routeConfig: { path: 'price-list' }
+    } as unknown as ActivatedRouteSnapshot;
+
+    const mockRouterStateSnapshot: RouterStateSnapshot =
+      {} as RouterStateSnapshot;
+
+    let config = TestConstants.CONFIG;
+    config.features = ['attestation_identity_records'];
+    MockConfigService.getConfig$.and.returnValue(of(config));
+
+    guard
+      .canActivate(mockActivatedRouteSnapshot, mockRouterStateSnapshot)
+      .subscribe((res) => {
+        expect(res).toBeTrue();
+      });
+  });
+
+  it('should fail unavailable components in a attestation bank', () => {
+    const mockActivatedRouteSnapshot: ActivatedRouteSnapshot = {
+      routeConfig: { path: 'identity-verification' }
+    } as unknown as ActivatedRouteSnapshot;
+
+    const mockRouterStateSnapshot: RouterStateSnapshot =
+      {} as RouterStateSnapshot;
+
+    let config = TestConstants.CONFIG;
+    config.features = ['attestation_identity_records'];
+    MockConfigService.getConfig$.and.returnValue(of(config));
 
     guard
       .canActivate(mockActivatedRouteSnapshot, mockRouterStateSnapshot)

--- a/library/src/shared/i18n/en.ts
+++ b/library/src/shared/i18n/en.ts
@@ -162,10 +162,8 @@ export default {
 
     // Confirm dialog
     confirm: {
-      title: 'Select Currency',
-      subtitle:
-        'We are unable to determine the currency of your account. Please select the correct currency from the options below.',
-      label: 'Currency'
+      title: 'Confirm Currency',
+      message: 'This account is in '
     }
   },
 

--- a/library/src/shared/services/config/config.service.spec.ts
+++ b/library/src/shared/services/config/config.service.spec.ts
@@ -15,7 +15,6 @@ import { Constants, TestConstants } from '@constants';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import {
-  BankBankModel,
   BanksService,
   Configuration,
   CustomerBankModel,
@@ -62,7 +61,6 @@ describe('ConfigService', () => {
       of(TestConstants.CUSTOMER_BANK_MODEL)
     );
     MockBanksService = TestBed.inject(BanksService);
-    MockBanksService.getBank.and.returnValue(of(TestConstants.BANK_BANK_MODEL));
   });
 
   it('should be created', () => {
@@ -186,14 +184,5 @@ describe('ConfigService', () => {
       .subscribe((customer) =>
         expect(customer).toEqual(TestConstants.CUSTOMER_BANK_MODEL)
       );
-  });
-
-  it('should fetch bank data', () => {
-    expect(service.getBank$()).toBeInstanceOf(Observable<BankBankModel>);
-
-    service
-      .getBank$()
-      .pipe(take(1))
-      .subscribe((bank) => expect(bank).toEqual(TestConstants.BANK_BANK_MODEL));
   });
 });

--- a/library/src/shared/services/config/config.service.ts
+++ b/library/src/shared/services/config/config.service.ts
@@ -12,14 +12,12 @@ import {
   Subject,
   switchMap,
   takeUntil,
-  tap,
   timer
 } from 'rxjs';
 
 // Services
 import { ErrorService, CODE, EventService, LEVEL } from '@services';
 import {
-  BankBankModel,
   BanksService,
   Configuration,
   CustomerBankModel,
@@ -37,6 +35,7 @@ export interface ComponentConfig {
   routing: boolean;
   customer: string; // Temporary solution until the JWT embeds a customer GUID
   fiat: string;
+  features: Array<string>;
   environment: 'local' | 'staging' | 'sandbox' | 'production';
 }
 
@@ -50,7 +49,6 @@ export class ConfigService implements OnDestroy {
   component$ = new ReplaySubject<string>(1);
 
   customer$ = new ReplaySubject<CustomerBankModel>(1);
-  bank$ = new ReplaySubject<BankBankModel>(1);
 
   private unsubscribe$ = new Subject();
 
@@ -205,14 +203,8 @@ export class ConfigService implements OnDestroy {
         switchMap((config) => {
           return this.customersService.getCustomer(config.customer);
         }),
-        tap((customer: CustomerBankModel) => {
+        map((customer: CustomerBankModel) => {
           this.customer$.next(customer);
-        }),
-        switchMap((customer: CustomerBankModel) =>
-          this.banksService.getBank(customer.bank_guid!)
-        ),
-        tap((bank) => {
-          this.bank$.next(bank);
         })
       )
       .subscribe();
@@ -220,9 +212,5 @@ export class ConfigService implements OnDestroy {
 
   getCustomer$(): Observable<CustomerBankModel> {
     return this.customer$.asObservable();
-  }
-
-  getBank$(): Observable<BankBankModel> {
-    return this.bank$.asObservable();
   }
 }

--- a/library/src/shared/services/routing/routing.service.spec.ts
+++ b/library/src/shared/services/routing/routing.service.spec.ts
@@ -16,7 +16,6 @@ import { Configuration } from '@cybrid/cybrid-api-bank-angular';
 
 // Utility
 import { TranslateService } from '@ngx-translate/core';
-import { TestConstants } from '@constants';
 
 describe('RoutingService', () => {
   let service: RoutingService;
@@ -25,7 +24,6 @@ describe('RoutingService', () => {
 
   let MockConfigService = jasmine.createSpyObj('ConfigService', [
     'getConfig$',
-    'getBank$',
     'setComponent'
   ]);
 
@@ -52,9 +50,6 @@ describe('RoutingService', () => {
     MockTranslateService = TestBed.inject(TranslateService);
     MockEventService = TestBed.inject(EventService);
     MockConfigService = TestBed.inject(ConfigService);
-    MockConfigService.getBank$.and.returnValue(
-      of(TestConstants.BANK_BANK_MODEL)
-    );
     MockRouter = TestBed.inject(Router);
     MockRouter.navigate.and.returnValue(Promise.resolve(true));
   });


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [X] Feature
- [ ] Bug fix

### Linked issue
https://cybrid.atlassian.net/browse/CYB-1190

### Why
Until now the SDK has operated with bank tokens, but now needs to be converted to using customer tokens

### How
Added a `features` key to the `config` and removed any calls to the banks API