### PR TITLE
fix: update bank-account list/connect routing

### DIFF
--- a/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.ts
+++ b/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.ts
@@ -69,7 +69,7 @@ export class BankAccountConnectComponent implements OnInit {
 
   routingData: RoutingData = {
     origin: 'bank-account-connect',
-    route: 'price-list'
+    route: 'bank-account-list'
   };
 
   params: NavigationExtras | undefined;

--- a/library/src/app/components/bank-account-management/bank-account-list/bank-account-list.component.ts
+++ b/library/src/app/components/bank-account-management/bank-account-list/bank-account-list.component.ts
@@ -78,7 +78,7 @@ export class BankAccountListComponent implements OnInit, OnDestroy {
 
   routingData: RoutingData = {
     route: 'bank-account-connect',
-    origin: 'bank-account-management'
+    origin: 'cybrid-app'
   };
 
   constructor(


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [X] Bug fix

### Linked issue
- [X] Not tracked

### Why
The bank-account-list 'ADD ACCOUNT' button needs to be whitelisted for `routing = false`, and bank-account-connect component needs to route to the bank-account-list on 'CANCEL' and 'DONE'

### How
Whitelisted 'ADD ACCOUNT', and changed routing behaviour in the bank-account-connect component