### PR TITLE
fix: session demo expiry

### DIFF
--- a/library/src/shared/i18n/en.ts
+++ b/library/src/shared/i18n/en.ts
@@ -227,5 +227,10 @@ export default {
       details: 'Details',
       state: 'State'
     }
+  },
+
+  // Auth service
+  auth: {
+    expired: 'User session has expired. Please login again.'
   }
 };

--- a/library/src/shared/i18n/fr.ts
+++ b/library/src/shared/i18n/fr.ts
@@ -231,5 +231,10 @@ export default {
       details: 'Détails',
       state: 'État'
     }
+  },
+
+  // Auth service
+  auth: {
+    expired: 'La session utilisateur a expiré. Veuillez vous reconnecter.'
   }
 };

--- a/src/demo/services/auth/auth.service.ts
+++ b/src/demo/services/auth/auth.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Router } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import {
   BehaviorSubject,
@@ -51,7 +52,8 @@ export class AuthService {
     private http: HttpClient,
     private router: Router,
     private localStorageService: LocalStorageService,
-    private eventService: EventService
+    private eventService: EventService,
+    private snackbar: MatSnackBar
   ) {}
 
   createCustomerToken(
@@ -139,14 +141,19 @@ export class AuthService {
 
   createSession(decodedToken: JwtPayload) {
     const key = Object(decodedToken)['sub_type'];
-    const expiresIn =
-      (<number>decodedToken.exp - <number>decodedToken.iat) * 1000;
+    const expiresIn = <number>decodedToken.exp * 1000 - Date.now();
 
     if (this.sessions[key]) this.sessions[key].unsubscribe();
 
-    this.sessions[key] = timer(expiresIn).subscribe(() =>
-      this.destroySession()
-    );
+    this.sessions[key] = timer(expiresIn).subscribe(() => {
+      this.destroySession();
+
+      this.snackbar.open(
+        'User session has expired. Please login again.',
+        'Ok',
+        { duration: 5000 }
+      );
+    });
   }
 
   restoreEnvironment(token: JwtPayload): string | null {

--- a/src/demo/services/auth/auth.service.ts
+++ b/src/demo/services/auth/auth.service.ts
@@ -35,6 +35,7 @@ import { Environment } from '@services';
 
 // Utility
 import { environment } from '../../../environments/environment';
+import { TranslatePipe } from '@ngx-translate/core';
 
 @Injectable({
   providedIn: 'root'
@@ -53,7 +54,8 @@ export class AuthService {
     private router: Router,
     private localStorageService: LocalStorageService,
     private eventService: EventService,
-    private snackbar: MatSnackBar
+    private snackbar: MatSnackBar,
+    private translatePipe: TranslatePipe
   ) {}
 
   createCustomerToken(
@@ -148,11 +150,9 @@ export class AuthService {
     this.sessions[key] = timer(expiresIn).subscribe(() => {
       this.destroySession();
 
-      this.snackbar.open(
-        'User session has expired. Please login again.',
-        'Ok',
-        { duration: 5000 }
-      );
+      this.snackbar.open(this.translatePipe.transform('auth.expired'), 'Ok', {
+        duration: 5000
+      });
     });
   }
 


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [X] Bug fix

### Linked issue
https://cybrid.atlassian.net/browse/CYB-1201

### Why
Session storage was incorrectly calculating the session expiry. We also need to inform users why they are being logged out.

### How
Fixed the expiry calculation. When the session has been destroyed the app routes to the login component and displays a snack bar message: 'User session has expired. Please login again.'

![Screen Shot 2023-04-27 at 10 05 47 AM](https://user-images.githubusercontent.com/5817894/234887064-129be8eb-4806-49c5-9bc4-eebea23b21ca.png)
