### PR TITLE
fix: asset service calling default environment

### DIFF
--- a/library/src/shared/services/asset/asset.service.spec.ts
+++ b/library/src/shared/services/asset/asset.service.spec.ts
@@ -18,13 +18,13 @@ import {
 import {
   Asset,
   AssetService,
-  AuthService,
+  ConfigService,
   EventService,
   ErrorService
 } from '@services';
 
 // Utility
-import { Constants } from '@constants';
+import { Constants, TestConstants } from '@constants';
 
 describe('AssetService', () => {
   let assetService: AssetService;
@@ -45,8 +45,8 @@ describe('AssetService', () => {
   let MockAssetsService = jasmine.createSpyObj('AssetsService', {
     listAssets: of(testAssetList)
   });
-  let MockAuthService = jasmine.createSpyObj('AuthService', {
-    getToken$: of(true)
+  let MockConfigService = jasmine.createSpyObj('ConfigService', {
+    getConfig$: of(TestConstants.CONFIG)
   });
   let MockEventService = jasmine.createSpyObj('EventService', ['handleEvent']);
   let MockErrorService = jasmine.createSpyObj('ErrorService', ['handleError']);
@@ -56,14 +56,14 @@ describe('AssetService', () => {
       imports: [HttpClientTestingModule],
       providers: [
         { provide: AssetsService, useValue: MockAssetsService },
-        { provide: AuthService, useValue: MockAuthService },
+        { provide: ConfigService, useValue: MockConfigService },
         { provide: EventService, useValue: MockEventService },
         { provide: ErrorService, useValue: MockErrorService }
       ]
     });
     assetService = TestBed.inject(AssetService);
     MockAssetsService = TestBed.inject(AssetsService);
-    MockAuthService = TestBed.inject(AuthService);
+    MockConfigService = TestBed.inject(ConfigService);
     MockEventService = TestBed.inject(EventService);
     MockErrorService = TestBed.inject(ErrorService);
   });
@@ -74,14 +74,14 @@ describe('AssetService', () => {
 
   it('should initialize assets', () => {
     assetService.initAssets();
-    expect(MockAuthService.getToken$).toHaveBeenCalled();
+    expect(MockConfigService.getConfig$).toHaveBeenCalled();
   });
 
   it('should log an event and error if initializing assets is unsuccessful', fakeAsync(() => {
     const error$ = throwError(() => {
       return new Error('Error');
     });
-    MockAuthService.getToken$.and.returnValue(error$);
+    MockConfigService.getConfig$.and.returnValue(error$);
     MockAssetsService.listAssets.and.returnValue([]);
     assetService.initAssets();
     tick(1000);

--- a/library/src/shared/services/asset/asset.service.ts
+++ b/library/src/shared/services/asset/asset.service.ts
@@ -9,13 +9,14 @@ import {
   switchMap,
   catchError,
   of,
-  ReplaySubject
+  ReplaySubject,
+  take
 } from 'rxjs';
 import { CODE, EventService, LEVEL } from '../event/event.service';
 import { ErrorService } from '../error/error.service';
 import { AssetBankModel } from '@cybrid/cybrid-api-bank-angular/model/asset';
-import { AuthService } from '../auth/auth.service';
-import { Constants } from '../../constants/constants';
+import { ConfigService } from '../config/config.service';
+import { Constants } from '@constants';
 
 export interface Asset extends AssetBankModel {
   type: AssetBankModel.TypeEnum;
@@ -38,7 +39,7 @@ export class AssetService {
 
   constructor(
     private assetsService: AssetsService,
-    private authService: AuthService,
+    private configService: ConfigService,
     private eventService: EventService,
     private errorService: ErrorService
   ) {
@@ -46,9 +47,10 @@ export class AssetService {
   }
 
   initAssets(): void {
-    this.authService
-      .getToken$()
+    this.configService
+      .getConfig$()
       .pipe(
+        take(1),
         switchMap(() => this.assetsService.listAssets()),
         map((list: AssetListBankModel) => {
           this.assets$.next(list.objects);


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [x] Bug fix

### Linked issue
- [x] Not tracked

### Why
The asset service was fetching the default config and using its environment value before the app updated the config.

### How
Fetch the config instead of the auth token when initializing the assets.