### PR TITLE
feat: update Cypress config timeouts

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -5,8 +5,9 @@ export default defineConfig({
   screenshotsFolder: 'cypress/screenshots',
   fixturesFolder: 'cypress/fixtures',
   chromeWebSecurity: false,
-  defaultCommandTimeout: 10000,
+  defaultCommandTimeout: 20000,
   requestTimeout: 15000,
+  responseTimeout: 15000,
   env: {
     CLIENT_ID_PLAID: '',
     CLIENT_SECRET_PLAID: '',
@@ -17,6 +18,6 @@ export default defineConfig({
   },
   e2e: {
     baseUrl: 'http://localhost:4200',
-    excludeSpecPattern: 'cypress/e2e/trade.cy.ts',
+    excludeSpecPattern: 'cypress/e2e/trade.cy.ts'
   }
 });


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [X] Bug fix

### Linked issue
- [X] Not tracked

### Why
Cypress commands are timing out waiting on some network calls to complete.

### How
Increased timeouts to allow for slower network speeds.