### PR TITLE
feat: update e2e to reduce mocking platform calls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,8 @@ jobs:
     working_directory: ~/project
     steps:
       - checkout
+      - attach_workspace:
+          at: .
       - run:
           name: Update version tag
           command: |
@@ -102,6 +104,8 @@ workflows:
             - test
           executor: cypress
           post-checkout:
+            - attach_workspace:
+                at: .
             - run:
                 name: Install wget/unzip
                 command: |
@@ -116,6 +120,7 @@ workflows:
                   unzip chrome-linux.zip
           start: npm start
           command: npx cypress run --browser chrome-linux/chrome
+          no-workspace: true
           wait-on: http://localhost:4200
           store_artifacts: true
 
@@ -125,6 +130,8 @@ workflows:
             - test
           executor: cypress
           post-checkout:
+            - attach_workspace:
+                at: .
             - run:
                 name: Install wget/unzip
                 command: |
@@ -139,6 +146,7 @@ workflows:
                   unzip chrome-linux.zip
           start: npm start
           command: npx cypress run --browser chrome-linux/chrome
+          no-workspace: true
           wait-on: http://localhost:4200
           store_artifacts: true
 
@@ -148,6 +156,8 @@ workflows:
             - test
           executor: cypress
           post-checkout:
+            - attach_workspace:
+                at: .
             - run:
                 name: Install libraries
                 command: |
@@ -171,6 +181,8 @@ workflows:
             - test
           executor: cypress
           post-checkout:
+            - attach_workspace:
+                at: .
             - run:
                 name: Install libraries
                 command: |
@@ -185,6 +197,7 @@ workflows:
                   apt-get -f install -y microsoft-edge-stable
           start: npm start
           command: npx cypress run --browser edge
+          no-workspace: true
           wait-on: http://localhost:4200
           store_artifacts: true
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,6 @@ jobs:
     working_directory: ~/project
     steps:
       - checkout
-      - attach_workspace:
-          at: .
       - run:
           name: Update version tag
           command: |
@@ -92,6 +90,7 @@ workflows:
                 name: Audit
             - run:
                 command: npm run package:library
+                name: Build library
             - persist_to_workspace:
                 root: .
                 paths:
@@ -103,8 +102,6 @@ workflows:
             - test
           executor: cypress
           post-checkout:
-            - attach_workspace:
-                at: .
             - run:
                 name: Install wget/unzip
                 command: |
@@ -128,8 +125,6 @@ workflows:
             - test
           executor: cypress
           post-checkout:
-            - attach_workspace:
-                at: .
             - run:
                 name: Install wget/unzip
                 command: |
@@ -153,8 +148,6 @@ workflows:
             - test
           executor: cypress
           post-checkout:
-            - attach_workspace:
-                at: .
             - run:
                 name: Install libraries
                 command: |
@@ -178,8 +171,6 @@ workflows:
             - test
           executor: cypress
           post-checkout:
-            - attach_workspace:
-                at: .
             - run:
                 name: Install libraries
                 command: |

--- a/cypress/e2e/account-details.cy.ts
+++ b/cypress/e2e/account-details.cy.ts
@@ -1,5 +1,4 @@
-import { TestConstants } from '@constants';
-
+//@ts-ignore
 function app() {
   return cy.get('app-account-details');
 }
@@ -19,21 +18,10 @@ describe('account-details test', () => {
     cy.authenticate();
     cy.visit('/');
 
-    // Mock prices
-    cy.intercept('GET', 'api/prices*', (req) => {
-      req.reply(TestConstants.SYMBOL_PRICE_BANK_MODEL_ARRAY);
-    }).as('listPrices');
-    // Mock accounts
-    cy.intercept('GET', 'api/accounts*', (req) => {
-      req.reply(TestConstants.ACCOUNT_LIST_BANK_MODEL);
-    }).as('listAccounts');
-    // Mock trades
-    cy.intercept('GET', 'api/trades*', (req) => {
-      req.reply(TestConstants.TRADE_LIST_BANK_MODEL);
-    }).as('listTrades');
-    cy.intercept('GET', 'api/trades/*', (req) => {
-      req.reply(TestConstants.TRADE_LIST_BANK_MODEL.objects[0]);
-    }).as('getTrade');
+    cy.intercept('GET', 'api/prices*').as('listPrices');
+    cy.intercept('GET', 'api/accounts*').as('listAccounts');
+    cy.intercept('GET', 'api/trades*').as('listTrades');
+    cy.intercept('GET', 'api/trades/*').as('getTrade');
 
     accountDetailsSetup();
   });
@@ -45,45 +33,38 @@ describe('account-details test', () => {
   it('should display account data', () => {
     app()
       .find('.cybrid-header')
+      .should('not.be.empty')
       .should('contain.text', 'Bitcoin')
       .should('contain.text', 'BTC')
-      .should('contain.text', 'USD')
-      .should('contain.text', '$21,298.00')
-      .should('contain.text', '232.18708499')
-      .should('contain.text', '4,944,888.35');
+      .should('contain.text', 'USD');
   });
 
   it('should display trade data', () => {
     app()
       .find('tr')
+      .should('not.be.empty')
       .should('contain.text', 'Buy')
-      .should('contain.text', 'BTC')
-      .should('contain.text', 'Feb 24, 2023')
-      .should('contain.text', '0.00004298')
-      .should('contain.text', '$1.00')
-      .should('contain.text', '0.00004297')
-      .should('contain.text', '$1.00');
+      .should('contain.text', 'BTC');
   });
 
   it('should display trade summary', () => {
     // Select first trade in the table
     app().find('tr').contains('BTC').first().click();
 
+    cy.intercept('api/trades/*').as('getTrade');
+
     cy.wait('@getTrade').then(() => {
-      cy.get('.cybrid-subtitle').should('contain.text', '$1.00 USD in BTC');
-      cy.get('.cybrid-subheader-item')
-        .should('contain.text', '0989a082d...')
-        .should('contain.text', 'Feb 24, 2023');
+      cy.get('.cybrid-subtitle').should('contain.text', 'USD in BTC');
+      cy.get('.cybrid-subheader-item').should('not.be.empty');
       cy.get('.cybrid-list-item')
+        .should('not.be.empty')
         .should('contain.text', 'Status')
         .should('contain.text', 'Settling')
         .should('contain.text', 'Purchased amount')
-        .should('contain.text', '$1.00')
         .should('contain.text', 'USD')
         .should('contain.text', 'Purchased quantity')
-        .should('contain.text', '0.00004298 BTC')
-        .should('contain.text', 'Transaction fee')
-        .should('contain.text', '$0.00');
+        .should('contain.text', 'BTC')
+        .should('contain.text', 'Transaction fee');
       cy.get('app-trade-summary').find('button').click();
     });
   });
@@ -94,17 +75,6 @@ describe('account-details test', () => {
   });
 
   it('should refresh the account list and paginate', () => {
-    // Reset mocks
-    cy.intercept('GET', 'api/prices*', (req) => {
-      req.continue();
-    });
-    cy.intercept('GET', 'api/accounts*', (req) => {
-      req.continue();
-    }).as('listAccounts');
-    cy.intercept('GET', 'api/trades*', (req) => {
-      req.continue();
-    }).as('listTrades');
-
     // Intercept listAccounts response
     let account;
     cy.wait('@listAccounts').then((interception) => {
@@ -143,14 +113,14 @@ describe('account-details test', () => {
   });
 
   it('should handle errors returned by trades api', () => {
-    // Force prices error
-    cy.intercept('GET', 'api/trades*', { forceNetworkError: true }).as(
-      'listTrades'
+    // Force trades error
+    cy.wait('@listTrades').then(() =>
+      cy
+        .intercept('GET', 'api/trades*', { forceNetworkError: true })
+        .as('listTrades')
     );
 
-    cy.wait('@listTrades').then(() => {
-      app().find('#warning').should('exist');
-    });
+    cy.wait('@listTrades').then(() => app().find('#warning').should('exist'));
   });
 
   it('should navigate to onTrade()', () => {

--- a/cypress/e2e/account-list.cy.ts
+++ b/cypress/e2e/account-list.cy.ts
@@ -72,23 +72,27 @@ describe('account-list test', () => {
     // Force accounts error
     cy.intercept('GET', '/api/accounts*').as('listAccounts');
 
-    cy.wait('@listAccounts').then(() => {
-      cy.intercept('GET', '/api/accounts*', { forceNetworkError: true });
-    });
+    cy.wait('@listAccounts').then(() =>
+      cy
+        .intercept('GET', '/api/accounts*', { forceNetworkError: true })
+        .as('listAccounts')
+    );
 
     // Check for error row
-    app().find('#warning').should('exist');
+    cy.wait('@listAccounts').then(() => app().find('#warning').should('exist'));
   });
 
   it('should handle errors returned by prices api', () => {
     // Force prices error
     cy.intercept('GET', '/api/prices*').as('listPrices');
 
-    cy.wait('@listPrices').then(() => {
-      cy.intercept('GET', '/api/prices*', { forceNetworkError: true });
-    });
+    cy.wait('@listPrices').then(() =>
+      cy
+        .intercept('GET', '/api/prices*', { forceNetworkError: true })
+        .as('listPrices')
+    );
 
     // Check for error row
-    app().find('#warning').should('exist');
+    cy.wait('@listPrices').then(() => app().find('#warning').should('exist'));
   });
 });

--- a/cypress/e2e/price-list.cy.ts
+++ b/cypress/e2e/price-list.cy.ts
@@ -18,19 +18,21 @@ describe('price-list test', () => {
     cy.authenticate();
     cy.visit('/');
 
+    cy.intercept('/api/prices').as('getPrices');
+
     priceListSetup();
   });
 
   it('should render the price list', () => {
-    cy.intercept('/api/prices').as('getPrices');
-    cy.wait('@getPrices');
-    app()
-      .should('exist')
-      .get('.cybrid-asset-cell')
-      .should('contain', 'BTC')
-      .and('contain', 'ETH')
-      .find('#price')
-      .should('not.equal', '$0.00');
+    cy.wait('@getPrices').then(() => {
+      app()
+        .should('exist')
+        .get('.cybrid-asset-cell')
+        .should('contain', 'BTC')
+        .and('contain', 'ETH')
+        .find('#price')
+        .should('not.equal', '$0.00');
+    });
   });
 
   it('should filter results', () => {
@@ -56,22 +58,24 @@ describe('price-list test', () => {
   it('should refresh the price list', () => {
     // Intercept getPrice response
     let prices;
-    cy.intercept('/api/prices').as('getPrices');
     cy.wait('@getPrices').then((interception) => {
       // @ts-ignore
       prices = interception.response.body;
     });
 
-    cy.wait('@getPrices').its('response.body').should('not.eq', prices);
-
-    app()
-      .find('tr')
-      .should('not.contain', 'Error fetching coins')
+    cy.wait('@getPrices')
+      .its('response.body')
+      .should('not.eq', prices)
       .then(() => {
         app()
-          .find('.cybrid-asset-cell')
-          .should('contain', 'BTC')
-          .and('contain', 'ETH');
+          .find('tr')
+          .should('not.contain', 'Error fetching coins')
+          .then(() => {
+            app()
+              .find('.cybrid-asset-cell')
+              .should('contain', 'BTC')
+              .and('contain', 'ETH');
+          });
       });
   });
 });


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [X] Feature
- [ ] Bug fix

### Linked issue
- [X] Not tracked

### Why
Flaky Cypress e2e tests are causing random failures with the new demo app configuration.

### How
By almost removing all mocked api calls. Also, added no-workspace back to e2e jobs. It appears it's not deprecated, just undocumented and is colliding with attaching the current persisted workspace in the publish job.