### PR TITLE
fix: default routing on destroy

### DIFF
--- a/library/src/app/components/app/app.component.ts
+++ b/library/src/app/components/app/app.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   EventEmitter,
   Input,
+  OnDestroy,
   OnInit,
   Output
 } from '@angular/core';
@@ -42,7 +43,7 @@ import { Configuration } from '@cybrid/cybrid-api-bank-angular';
   styleUrls: ['./app.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class AppComponent implements OnInit {
+export class AppComponent implements OnInit, OnDestroy {
   @Output() eventLog = new EventEmitter<EventLog>();
   @Output() errorLog = new EventEmitter<ErrorLog>();
 
@@ -108,6 +109,12 @@ export class AppComponent implements OnInit {
       .subscribe(() => {
         this.initNavigation();
       });
+  }
+
+  ngOnDestroy() {
+    this.unsubscribe$.next('');
+    this.unsubscribe$.complete();
+    this.router.navigate(['/']);
   }
 
   initEventService(): void {

--- a/library/src/app/modules/routing.module.ts
+++ b/library/src/app/modules/routing.module.ts
@@ -18,12 +18,8 @@ import { ComponentGuard } from '@guards';
 export const routes: Routes = [
   {
     path: '',
-    redirectTo: 'app/price-list',
+    redirectTo: 'app',
     pathMatch: 'full'
-  },
-  {
-    path: 'app',
-    redirectTo: 'app/price-list'
   },
   {
     path: 'app',
@@ -72,7 +68,7 @@ export const routes: Routes = [
   },
   {
     path: '**',
-    redirectTo: 'app/price-list'
+    redirectTo: 'app'
   }
 ];
 


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [x] Bug fix

### Linked issue
https://cybrid.atlassian.net/browse/CYB-1310

### Why
When the Web SDK is first initialized and then destroyed, the routing module and all its services persist. Re-routing to a component when using the web element implementation `<cybrid-app></cybrid-app>` causes the SDK to attempt to initialize on the previously set route, and the application appears to be stuck in a loading animation.

### How
By navigating to the default route in the onDestroy hook of `AppComponent`