### PR TITLE
chore: update github action demo deploy script

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Install and Build
         run: |
           npm ci
+          npm run package:library
           npm run build
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4.4.1


### PR DESCRIPTION
### Type of change

- [X] Chore
- [ ] Feature
- [ ] Bug fix

### Linked issue
- [X] Not tracked

### Why
The deployed demo now includes the Web SDK library as a script, and the Github action now needs to build the library before the demo.

### How
Added the build library command to the deploy action.