### PR TITLE
fix: wait for customer call to route to component

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -29,6 +29,8 @@ Cypress.Commands.add('authenticate', () => {
   cy.session(
     'auth',
     () => {
+      cy.intercept('GET', 'api/customers/*').as('getCustomer');
+
       cy.visit('/');
       app()
         .should('exist')
@@ -43,6 +45,7 @@ Cypress.Commands.add('authenticate', () => {
         .should('not.exist')
         .then(() => {
           cy.window().getAllLocalStorage().should('not.eq', {});
+          cy.wait('@getCustomer');
         });
     },
     {


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [X] Bug fix

### Linked issue
- [X] Not tracked

### Why
Cypress is attempting to route to a component before the SDK is initialized

### How
Wait for the SDK's customer call during authentication before routing