### PR TITLE
feat: update bank-account-connect to handle mobile

### DIFF
--- a/library/README.md
+++ b/library/README.md
@@ -20,7 +20,7 @@ Crypto currency icon assets: [https://images.cybrid.xyz/](https://images.cybrid.
 
 To use the application via html load it into your index.html as a script.
 
-The script registers `cybrid-app` as a web-component in your window. 
+The script registers `cybrid-app` as a web-component in your window.
 
 > NOTE: If you are embedding this library in an Angular application you will want to omit `cybrid-sdk-ui.polyfills.js` to avoid duplication of `zone.js`
 
@@ -127,6 +127,12 @@ interface ComponentConfig {
   // The environment that you are authenticated against
   // Supports: 'sandbox' | 'production'
   environment: string;
+
+  // The redirect Uri that the Plaid SDK uses to return from a mobile OAuth flow
+  // It must be registered with Cybrid so that we may add it to an internal Plaid allow-list
+  // If this is undefined and on web-mobile the bank-account-connect component will return an Error, and serve a message to the user that explains mobile access is unavailable
+  // The query parameter 'oauth_state_id' returned from Plaid must be present in the url when you re-render the bank-account-connect component after authentication
+  redirectUri?: string;
 }
 ```
 
@@ -153,7 +159,7 @@ your_config = {
 
 ### `component` (optional)
 
-The currently displayed component. By default the `price-list` component is rendered.
+The currently displayed component. By default, the `price-list` component is rendered.
 
 Components:
 

--- a/library/src/app/modules/library.module.ts
+++ b/library/src/app/modules/library.module.ts
@@ -162,6 +162,7 @@ export function HttpLoaderFactory(http: HttpClient) {
     AssetFormatPipe,
     TruncatePipe,
     TranslatePipe,
+    { provide: Window, useValue: window },
     { provide: APP_BASE_HREF, useValue: '' },
     { provide: HTTP_INTERCEPTORS, useClass: RetryInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor, multi: true },

--- a/library/src/shared/constants/test.constants.ts
+++ b/library/src/shared/constants/test.constants.ts
@@ -40,7 +40,8 @@ export class TestConstants {
     customer: 'e8dc9202e0e96a33b5b6a7b0cfb66c60',
     fiat: 'USD',
     features: ['attestation_identity_records', 'backstopped_funding_source'],
-    environment: 'staging'
+    environment: 'staging',
+    redirectUri: 'http://localhost:4200/demo/bank-account-connect'
   };
 
   static ASSET_LIST_BANK_MODEL: AssetListBankModel = {

--- a/library/src/shared/services/bank-account/bank-account.service.spec.ts
+++ b/library/src/shared/services/bank-account/bank-account.service.spec.ts
@@ -19,7 +19,7 @@ import {
   WorkflowsService
 } from '@cybrid/cybrid-api-bank-angular';
 
-describe('BankAccountManagementService', () => {
+describe('BankAccountService', () => {
   let service: BankAccountService;
   let MockEventService = jasmine.createSpyObj('EventService', [
     'getEvent',
@@ -237,7 +237,8 @@ describe('BankAccountManagementService', () => {
       customer_guid: '',
       external_bank_account_guid: externalBankAccountGuid,
       link_customization_name: 'default',
-      language: 'en'
+      language: 'en',
+      redirect_uri: TestConstants.CONFIG.redirectUri
     };
 
     service

--- a/library/src/shared/services/bank-account/bank-account.service.ts
+++ b/library/src/shared/services/bank-account/bank-account.service.ts
@@ -86,6 +86,7 @@ export class BankAccountService implements OnDestroy {
 
           this.postExternalBankAccountModel.customer_guid = config.customer;
           this.postWorkflowBankModel.customer_guid = config.customer;
+          this.postWorkflowBankModel.redirect_uri = config.redirectUri;
           this.postWorkflowBankModel.language = getLanguageFromLocale(
             config.locale
           ) as PostWorkflowBankModel.LanguageEnum;

--- a/library/src/shared/services/config/config.service.ts
+++ b/library/src/shared/services/config/config.service.ts
@@ -38,6 +38,7 @@ export interface ComponentConfig {
   fiat: string;
   features: Array<string>;
   environment: Environment;
+  redirectUri?: string;
 }
 
 @Injectable({

--- a/src/demo/modules/demo-viewer/components/demo-details/demo-details.component.ts
+++ b/src/demo/modules/demo-viewer/components/demo-details/demo-details.component.ts
@@ -61,17 +61,22 @@ export class DemoDetailsComponent implements AfterViewInit, OnDestroy {
           this._renderer2.setProperty(sdk, 'config', config);
           this._renderer2.setProperty(sdk, 'component', params['id']);
 
+          // Update routed component, and any query params
+          this.location.replaceState(`demo/${params['id'] + location.search}`);
+
           // Subscribe to logging
           this._renderer2.listen(sdk, 'eventLog', (event) => {
             console.log(event.detail);
 
-            // Update current url path as SDK component path on SDK routing events
+            // Update current url path
             const eventLog = event.detail as EventLog;
             if (eventLog.code === 'ROUTING_END') {
               const component = eventLog.data['default'];
 
               this.demoViewerService.updateRoute(component);
-              this.location.replaceState(`demo/${component}`);
+
+              // Update routed component, and any query params
+              this.location.replaceState(`demo/${component + location.search}`);
             }
           });
 

--- a/src/demo/services/config/config.service.ts
+++ b/src/demo/services/config/config.service.ts
@@ -5,7 +5,7 @@ import { Observable, of, ReplaySubject, switchMap, throwError } from 'rxjs';
 
 // Library
 import { ComponentConfig } from '@services';
-import { Constants } from '@constants';
+import { Constants, TestConstants } from '@constants';
 
 // Services
 import { AuthService } from '../auth/auth.service';
@@ -62,6 +62,7 @@ export class ConfigService {
           config.customer = this.authService.customer;
           config.features = bank.features;
           config.environment = this.authService.environment;
+          config.redirectUri = TestConstants.CONFIG.redirectUri;
 
           this.config.next(config);
           return of(config);


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [X] Feature
- [ ] Bug fix

### Linked issue
https://cybrid.atlassian.net/browse/CYB-1278

### Why
We need to allow mobile users to access `bank-account-connect`

### How
Added a `redirectUri` to the config and updated `bank-account-connect` to handle a callback from Plaid during a mobile OAuth flow