### PR TITLE
bug: fix demo component selector emit event

### DIFF
--- a/src/demo/modules/demo-viewer/components/demo-viewer/demo-viewer.component.ts
+++ b/src/demo/modules/demo-viewer/components/demo-viewer/demo-viewer.component.ts
@@ -34,6 +34,7 @@ export class DemoViewerComponent implements OnInit {
   config = Constants.DEFAULT_CONFIG;
 
   unsubscribe$ = new Subject();
+
   constructor(
     private demoViewerService: DemoViewerService,
     private activatedRoute: ActivatedRoute,
@@ -99,10 +100,9 @@ export class DemoViewerComponent implements OnInit {
     this.demoViewerService.route$
       .pipe(
         tap((component) =>
-          this.componentGroup.get('component')?.patchValue(component, {
-            emitEvent: false,
-            onlySelf: true
-          })
+          this.componentGroup
+            .get('component')
+            ?.patchValue(component, { onlySelf: true })
         )
       )
       .subscribe();


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [X] Bug fix

### Linked issue
https://cybrid.atlassian.net/browse/CYB-1339

### Why
The Demo component selector sometimes won’t emit an event on changes, which doesn’t trigger its valueChanges and won’t fire a navigation event

### How
By removing `emitEvent: false`