### PR TITLE
feat: handle backstopped type removal

### DIFF
--- a/library/src/shared/constants/test.constants.ts
+++ b/library/src/shared/constants/test.constants.ts
@@ -243,7 +243,7 @@ export class TestConstants {
         state: 'created'
       },
       {
-        type: 'backstopped',
+        type: 'fiat',
         guid: 'c907b45a8eae49f135dc0d2eee734dce',
         created_at: '2022-04-30T03:40:54.677Z',
         asset: 'USD',

--- a/library/src/shared/guards/component.guard.spec.ts
+++ b/library/src/shared/guards/component.guard.spec.ts
@@ -106,7 +106,7 @@ describe('ComponentGuard', () => {
       {} as RouterStateSnapshot;
 
     let config = TestConstants.CONFIG;
-    config.features = ['identity-verification'];
+    config.features = ['attestation_identity_records'];
     MockConfigService.getConfig$.and.returnValue(of(config));
 
     guard

--- a/library/src/shared/guards/component.guard.spec.ts
+++ b/library/src/shared/guards/component.guard.spec.ts
@@ -59,44 +59,6 @@ describe('ComponentGuard', () => {
     expect(guard).toBeTruthy();
   });
 
-  it('should pass allowed components in a backstopped bank', () => {
-    const mockActivatedRouteSnapshot: ActivatedRouteSnapshot = {
-      routeConfig: { path: 'price-list' }
-    } as unknown as ActivatedRouteSnapshot;
-
-    const mockRouterStateSnapshot: RouterStateSnapshot =
-      {} as RouterStateSnapshot;
-
-    let config = TestConstants.CONFIG;
-    config.features = ['backstopped_funding_source'];
-    MockConfigService.getConfig$.and.returnValue(of(config));
-
-    guard
-      .canActivate(mockActivatedRouteSnapshot, mockRouterStateSnapshot)
-      .subscribe((res) => {
-        expect(res).toBeTrue();
-      });
-  });
-
-  it('should fail unavailable components in a backstopped bank', () => {
-    const mockActivatedRouteSnapshot: ActivatedRouteSnapshot = {
-      routeConfig: { path: 'transfer' }
-    } as unknown as ActivatedRouteSnapshot;
-
-    const mockRouterStateSnapshot: RouterStateSnapshot =
-      {} as RouterStateSnapshot;
-
-    let config = TestConstants.CONFIG;
-    config.features = ['backstopped_funding_source'];
-    MockConfigService.getConfig$.and.returnValue(of(config));
-
-    guard
-      .canActivate(mockActivatedRouteSnapshot, mockRouterStateSnapshot)
-      .subscribe((res) => {
-        expect(res).toBeFalse();
-      });
-  });
-
   it('should pass allowed components in an attestation bank', () => {
     const mockActivatedRouteSnapshot: ActivatedRouteSnapshot = {
       routeConfig: { path: 'price-list' }
@@ -111,7 +73,7 @@ describe('ComponentGuard', () => {
 
     guard
       .canActivate(mockActivatedRouteSnapshot, mockRouterStateSnapshot)
-      .subscribe((res) => {
+      .subscribe((res: boolean) => {
         expect(res).toBeTrue();
       });
   });
@@ -130,21 +92,21 @@ describe('ComponentGuard', () => {
 
     guard
       .canActivate(mockActivatedRouteSnapshot, mockRouterStateSnapshot)
-      .subscribe((res) => {
+      .subscribe((res: boolean) => {
         expect(res).toBeFalse();
       });
   });
 
   it('should issue an event if routing is denied', fakeAsync(() => {
     const mockActivatedRouteSnapshot: ActivatedRouteSnapshot = {
-      routeConfig: { path: 'transfer' }
+      routeConfig: { path: 'identity-verification' }
     } as unknown as ActivatedRouteSnapshot;
 
     const mockRouterStateSnapshot: RouterStateSnapshot =
       {} as RouterStateSnapshot;
 
     let config = TestConstants.CONFIG;
-    config.features = ['backstopped_funding_source'];
+    config.features = ['identity-verification'];
     MockConfigService.getConfig$.and.returnValue(of(config));
 
     guard

--- a/library/src/shared/guards/component.guard.ts
+++ b/library/src/shared/guards/component.guard.ts
@@ -25,22 +25,6 @@ export class ComponentGuard implements CanActivate {
       map((config) => {
         if (
           config.features.includes(
-            BankBankModel.FeaturesEnum.BackstoppedFundingSource
-          ) &&
-          !Constants.COMPONENTS_BACKSTOPPED.includes(
-            <string>route.routeConfig?.path
-          )
-        ) {
-          this.eventService.handleEvent(
-            LEVEL.INFO,
-            CODE.ROUTING_DENIED,
-            'Component: ' +
-              route.routeConfig?.path +
-              ' is unavailable to backstopped banks'
-          );
-          return false;
-        } else if (
-          config.features.includes(
             BankBankModel.FeaturesEnum.AttestationIdentityRecords
           ) &&
           !Constants.COMPONENTS_ATTESTATION.includes(

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,13 @@
         "@angular/platform-browser": "15.2.9",
         "@angular/platform-browser-dynamic": "15.2.9",
         "@angular/router": "15.2.9",
+<<<<<<< HEAD
         "@cybrid/cybrid-api-bank-angular": "^0.81.0",
         "@cybrid/cybrid-api-id-angular": "^0.80.0",
+=======
+        "@cybrid/cybrid-api-bank-angular": "^0.80.0",
+        "@cybrid/cybrid-api-id-angular": "^0.81.0",
+>>>>>>> 2ee3932 (fix(deps): update dependency @cybrid/cybrid-api-id-angular to ^0.81.0)
         "@ngx-translate/core": "14.0.0",
         "@ngx-translate/http-loader": "7.0.0",
         "big.js": "6.2.1",
@@ -3044,9 +3049,9 @@
       }
     },
     "node_modules/@cybrid/cybrid-api-id-angular": {
-      "version": "0.80.1",
-      "resolved": "https://registry.npmjs.org/@cybrid/cybrid-api-id-angular/-/cybrid-api-id-angular-0.80.1.tgz",
-      "integrity": "sha512-+0hGrDp/yXcvDQ3ytkgsPg/ywYExAwhcXW4JIRiF4VDRozZl4Z9n4QW8XXwifHvob4MHh9cSAzH/mxvqItr5Vw==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@cybrid/cybrid-api-id-angular/-/cybrid-api-id-angular-0.81.1.tgz",
+      "integrity": "sha512-qaV5l7M6r04lQndJDuvCAfsc/onc9z3gfix8zG4T+rinH++ZwAcS8LJ324Bk4vVTDYnJUL2fgWWI+GsahX+IfA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@angular/platform-browser": "15.2.9",
         "@angular/platform-browser-dynamic": "15.2.9",
         "@angular/router": "15.2.9",
-        "@cybrid/cybrid-api-bank-angular": "^0.80.0",
+        "@cybrid/cybrid-api-bank-angular": "^0.81.0",
         "@cybrid/cybrid-api-id-angular": "^0.80.0",
         "@ngx-translate/core": "14.0.0",
         "@ngx-translate/http-loader": "7.0.0",
@@ -3032,9 +3032,9 @@
       }
     },
     "node_modules/@cybrid/cybrid-api-bank-angular": {
-      "version": "0.80.1",
-      "resolved": "https://registry.npmjs.org/@cybrid/cybrid-api-bank-angular/-/cybrid-api-bank-angular-0.80.1.tgz",
-      "integrity": "sha512-NKm1c2kOvwmYPTAymGIEkN56CZxq2+KZaSqdRveYVlDYPe+RS2cWMF/bYEoBlBpfDIUtSUfwwsnfxWGQCH5eiw==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@cybrid/cybrid-api-bank-angular/-/cybrid-api-bank-angular-0.81.1.tgz",
+      "integrity": "sha512-zuN2Y7XUNwMAEzjM/driCFQdcnc7c6pkN1c3BmKbwk3fYoBXNZGxiB7bTvYQ2Now0ahGzgG3cYwcOZVx9oucdQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@angular/platform-browser": "15.2.9",
     "@angular/platform-browser-dynamic": "15.2.9",
     "@angular/router": "15.2.9",
-    "@cybrid/cybrid-api-bank-angular": "^0.80.0",
+    "@cybrid/cybrid-api-bank-angular": "^0.81.0",
     "@cybrid/cybrid-api-id-angular": "^0.80.0",
     "@ngx-translate/core": "14.0.0",
     "@ngx-translate/http-loader": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@angular/platform-browser-dynamic": "15.2.9",
     "@angular/router": "15.2.9",
     "@cybrid/cybrid-api-bank-angular": "^0.81.0",
-    "@cybrid/cybrid-api-id-angular": "^0.80.0",
+    "@cybrid/cybrid-api-id-angular": "^0.81.0",
     "@ngx-translate/core": "14.0.0",
     "@ngx-translate/http-loader": "7.0.0",
     "big.js": "6.2.1",

--- a/src/demo/modules/demo-viewer/components/demo-viewer/demo-viewer.component.ts
+++ b/src/demo/modules/demo-viewer/components/demo-viewer/demo-viewer.component.ts
@@ -12,8 +12,6 @@ import { AuthService } from '../../../../services/auth/auth.service';
 import { ConfigService } from '../../../../services/config/config.service';
 import { DemoViewerService } from '../../services/demo-viewer.service';
 
-import { BankBankModel } from '@cybrid/cybrid-api-bank-angular';
-
 @Component({
   selector: 'app-sdk',
   templateUrl: './demo-viewer.component.html',
@@ -53,12 +51,6 @@ export class DemoViewerComponent implements OnInit {
     this.initLanguageGroup();
   }
 
-  isBackstopped(): boolean {
-    return this.config.features.includes(
-      BankBankModel.FeaturesEnum.BackstoppedFundingSource
-    );
-  }
-
   getTooltip(component: string): string {
     if (component == 'account-details')
       return 'Disabled: Navigate via account-list';
@@ -68,9 +60,7 @@ export class DemoViewerComponent implements OnInit {
     )
       return 'Disabled: Sign in as a private user to access';
     else {
-      if (this.isBackstopped() && this.isDisabled(component)) {
-        return 'Component is unavailable to backstopped banks';
-      } else return '';
+      return '';
     }
   }
 
@@ -81,11 +71,7 @@ export class DemoViewerComponent implements OnInit {
       component == 'identity-verification'
     )
       return true;
-    else {
-      if (this.isBackstopped()) {
-        return !Constants.COMPONENTS_BACKSTOPPED.includes(component);
-      } else return false;
-    }
+    else return false;
   }
 
   initComponentGroup() {


### PR DESCRIPTION
### Type of change

- [X] Chore
- [ ] Feature
- [ ] Bug fix

### Linked issue
https://cybrid.atlassian.net/browse/CYB-1401

### Why
Now that `api-paltform-bank` account `type: 'backstoppped'` has been removed we need to update the Web SDK and Demo application

### How
By updating references to `type: 'fiat'`, and adjusting the component guard rules