### PR TITLE
fix: trade account truncation

### DIFF
--- a/library/src/app/components/trade/trade.component.html
+++ b/library/src/app/components/trade/trade.component.html
@@ -24,15 +24,14 @@
                     <img matPrefix class="cybrid-trigger-icon" alt="Crypto currency icon"
                       src="{{ tradingAccount.value.asset | assetIcon }}" />
                     <span class="cybrid-trigger-name">{{
-                      tradingAccount.value.name | truncate : 24
+                      tradingAccount.value.name
                       }}</span>
                   </div>
                 </mat-select-trigger>
                 <mat-option *ngFor="let account of data.accounts.assets" [value]="account">
                   <div class="cybrid-option">
                     <img class="cybrid-option-icon" alt="Crypto currency icon" src="{{ account.asset | assetIcon }}" />
-                    <!-- TODO: Truncate more dynamically here -->
-                    <span>{{ account.name | truncate : 24 }}</span>
+                    <span>{{ account.name }}</span>
                   </div>
                 </mat-option>
               </mat-select>


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [x] Bug fix

### Linked issue
- [x] Not tracked

### Why
The account name in the`trade` component input and selector needs to be full width.

### How
Removed truncation.