### PR TITLE
fix: IDV resume state

### DIFF
--- a/library/src/app/components/identity-verification/identity-verification.component.spec.ts
+++ b/library/src/app/components/identity-verification/identity-verification.component.spec.ts
@@ -410,7 +410,7 @@ describe('IdentityVerificationComponent', () => {
     // Define Persona client with open method
     let client = {
       options: { inquiryId: '' },
-      open: () => { }
+      open: () => {}
     };
 
     component.personaOnReady(client);

--- a/library/src/app/components/identity-verification/identity-verification.component.spec.ts
+++ b/library/src/app/components/identity-verification/identity-verification.component.spec.ts
@@ -248,6 +248,46 @@ describe('IdentityVerificationComponent', () => {
       }));
     });
 
+    describe('with completed state', () => {
+      it('should create an identity verification', fakeAsync(() => {
+        let identityVerificationListBankModel = {
+          ...TestConstants.IDENTITY_VERIFICATION_LIST_BANK_MODEL
+        };
+        identityVerificationListBankModel.objects[0].state = 'completed';
+
+        MockIdentityVerificationService.listIdentityVerifications.and.returnValue(
+          of(identityVerificationListBankModel)
+        );
+
+        component.verifyIdentity();
+
+        tick();
+        expect(
+          MockIdentityVerificationService.createIdentityVerification
+        ).toHaveBeenCalled();
+
+        discardPeriodicTasks();
+
+        // Reset
+        MockIdentityVerificationService.listIdentityVerifications.and.returnValue(
+          of(TestConstants.IDENTITY_VERIFICATION_LIST_BANK_MODEL)
+        );
+      }));
+    });
+
+    describe('with storing state', () => {
+      it('should get the identity verification', fakeAsync(() => {
+        component.verifyIdentity();
+
+        tick();
+        expect(
+          MockIdentityVerificationService.getIdentityVerification
+        ).toHaveBeenCalled();
+
+        discardPeriodicTasks();
+      }));
+    });
+
     describe('with waiting state', () => {
       it('should get the identity verification', fakeAsync(() => {
         component.verifyIdentity();
@@ -370,7 +410,7 @@ describe('IdentityVerificationComponent', () => {
     // Define Persona client with open method
     let client = {
       options: { inquiryId: '' },
-      open: () => {}
+      open: () => { }
     };
 
     component.personaOnReady(client);

--- a/library/src/app/components/identity-verification/identity-verification.component.ts
+++ b/library/src/app/components/identity-verification/identity-verification.component.ts
@@ -181,8 +181,10 @@ export class IdentityVerificationComponent implements OnInit, OnDestroy {
       .pipe(
         map((list) => list.objects[0]),
         switchMap((identity) => {
-          return identity &&
-            identity.state == IdentityVerificationBankModel.StateEnum.Waiting
+          return (identity &&
+            identity.state ==
+              IdentityVerificationBankModel.StateEnum.Waiting) ||
+            identity.state == IdentityVerificationBankModel.StateEnum.Storing
             ? of(identity)
             : this.identityVerificationService.createIdentityVerification();
         }),

--- a/library/src/app/components/identity-verification/identity-verification.component.ts
+++ b/library/src/app/components/identity-verification/identity-verification.component.ts
@@ -181,10 +181,9 @@ export class IdentityVerificationComponent implements OnInit, OnDestroy {
       .pipe(
         map((list) => list.objects[0]),
         switchMap((identity) => {
-          return (identity &&
-            identity.state ==
-              IdentityVerificationBankModel.StateEnum.Waiting) ||
-            identity.state == IdentityVerificationBankModel.StateEnum.Storing
+          return identity?.state ===
+            IdentityVerificationBankModel.StateEnum.Waiting ||
+            identity?.state === IdentityVerificationBankModel.StateEnum.Storing
             ? of(identity)
             : this.identityVerificationService.createIdentityVerification();
         }),

--- a/library/src/app/components/identity-verification/identity-verification.component.ts
+++ b/library/src/app/components/identity-verification/identity-verification.component.ts
@@ -182,7 +182,7 @@ export class IdentityVerificationComponent implements OnInit, OnDestroy {
         map((list) => list.objects[0]),
         switchMap((identity) => {
           return identity &&
-            identity.state !== IdentityVerificationBankModel.StateEnum.Expired
+            identity.state == IdentityVerificationBankModel.StateEnum.Waiting
             ? of(identity)
             : this.identityVerificationService.createIdentityVerification();
         }),


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [x] Bug fix

### Linked issue
- [x] Not tracked

### Why
When checking for existing IDVs the component passes a completed IDV through the flow even if a customer is `unverified`

### How
Ensure a new IDV is created unless the state on the most recent one is `waiting`