### PR TITLE
fix: asset paging

### DIFF
--- a/library/src/shared/services/asset/asset.service.spec.ts
+++ b/library/src/shared/services/asset/asset.service.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 
-import { of, throwError } from 'rxjs';
+import { of, Observable, throwError } from 'rxjs';
 
 // Client
 import {
@@ -89,6 +89,25 @@ describe('AssetService', () => {
     expect(MockErrorService.handleError).toHaveBeenCalled();
     expect(MockEventService.handleEvent).toHaveBeenCalled();
   }));
+
+  it('should page through assets', () => {
+    let assetList = {
+      ...TestConstants.ASSET_LIST_BANK_MODEL
+    };
+    assetList.objects = [];
+
+    // Fill objects with default amount per page
+    for (let i = 0; i < 10; i++) {
+      assetList.objects.push(TestConstants.ASSET_LIST_BANK_MODEL.objects[0]);
+    }
+
+    MockAssetsService.listAssets.and.returnValue(of(assetList));
+
+    assetService.listAssets();
+    expect(assetService.pageExternalAccounts(assetList)).toBeInstanceOf(
+      Observable<AssetListBankModel>
+    );
+  });
 
   it('should return the asset list as an observable', () => {
     assetService


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [x] Bug fix

### Linked issue
- [x] Not tracked

### Why
The asset service is only retrieving the first page of assets

### How
Add paging to the `asset-service`