### PR TITLE
fix: account list value

### DIFF
--- a/library/src/app/components/account/account-details/account-details.component.html
+++ b/library/src/app/components/account/account-details/account-details.component.html
@@ -130,7 +130,7 @@
           [ngClass]="{ 'cybrid-hide': totalRows <= 5 }" [pageSize]="pageSize" [pageIndex]="currentPage"
           [length]="totalRows" [pageSizeOptions]="pageSizeOptions" (page)="pageChange($event)">
         </mat-paginator>
-        <div class="cybrid-actions">
+        <div *ngIf="data.account?.price" class="cybrid-actions">
           <button id="trade" mat-flat-button color="primary" (click)="onTrade()">
             {{ 'accountDetails.trade' | translate }}
           </button>

--- a/library/src/app/components/account/account-list/account-list.component.html
+++ b/library/src/app/components/account/account-list/account-list.component.html
@@ -15,12 +15,11 @@
 
       <div class="cybrid-table">
         <mat-progress-bar *ngIf="isLoadingResults$ | async" mode="indeterminate"></mat-progress-bar>
-        <table id="accountList" class="mat-button-toggle-group-appearance-standard"
-          [ngClass]="{ 'cybrid-paginator': totalRows > pageSize }" mat-table [dataSource]="dataSource" matSort
-          matSortDisableClear (matSortChange)="sortChange()">
+        <table id="accountList" class="mat-button-toggle-group-appearance-standard" mat-table [dataSource]="dataSource"
+          matSort matSortDisableClear (matSortChange)="sortChange()">
           <!-- Account -->
           <ng-container matColumnDef="account">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header="">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header="account">
               <div class="cybrid-sort-header">
                 <span>{{ 'accountList.account.header' | translate }}</span>
                 <span class="mat-hint cybrid-h5 cybrid-code">{{
@@ -48,7 +47,7 @@
 
           <!-- Balance -->
           <ng-container matColumnDef="balance">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header="" arrowPosition="before">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header="balance" arrowPosition="before">
               <div class="cybrid-sort-header">
                 <span>{{ 'accountList.balance' | translate }}</span>
                 <span class="mat-hint cybrid-h5 cybrid-code">{{
@@ -97,10 +96,6 @@
       </div>
     </ng-container>
   </ng-container>
-  <mat-paginator class="mat-button-toggle-group-appearance-standard" aria-label="cryptocurrency accounts and balances"
-    [ngClass]="{ 'cybrid-hide': totalRows <= pageSize }" [pageSize]="pageSize" [pageIndex]="currentPage"
-    [length]="totalRows" [pageSizeOptions]="pageSizeOptions" (page)="pageChange($event)">
-  </mat-paginator>
 </ng-container>
 <ng-template #loading>
   <app-loading></app-loading>

--- a/library/src/app/components/account/account-list/account-list.component.html
+++ b/library/src/app/components/account/account-list/account-list.component.html
@@ -59,7 +59,7 @@
               <div class="cybrid-balance-cell">
                 <ng-container *ngIf="account.type === 'fiat'; else tradingAccount">
                   <span>
-                    {{ account.platform_available | assetFormat : config.fiat }}
+                    {{ account.value | assetFormat : account.asset }}
                   </span>
                   <span class="mat-hint cybrid-h5 cybrid-code" *ngIf="
                       account.platform_balance - account.platform_available > 0

--- a/library/src/app/components/account/account-list/account-list.component.html
+++ b/library/src/app/components/account/account-list/account-list.component.html
@@ -76,7 +76,7 @@
                   <span>{{
                     account.platform_balance | assetFormat : account.asset
                     }}</span>
-                  <span class="mat-hint cybrid-h5 cybrid-code">
+                  <span *ngIf="account.value !== undefined" class="mat-hint cybrid-h5 cybrid-code">
                     {{ account.value | assetFormat : config.fiat }}</span>
                 </ng-template>
               </div>
@@ -98,8 +98,8 @@
     </ng-container>
   </ng-container>
   <mat-paginator class="mat-button-toggle-group-appearance-standard" aria-label="cryptocurrency accounts and balances"
-    [ngClass]="{ 'cybrid-hide': totalRows <= 5 }" [pageSize]="pageSize" [pageIndex]="currentPage" [length]="totalRows"
-    [pageSizeOptions]="pageSizeOptions" (page)="pageChange($event)">
+    [ngClass]="{ 'cybrid-hide': totalRows <= pageSize }" [pageSize]="pageSize" [pageIndex]="currentPage"
+    [length]="totalRows" [pageSizeOptions]="pageSizeOptions" (page)="pageChange($event)">
   </mat-paginator>
 </ng-container>
 <ng-template #loading>

--- a/library/src/app/components/account/account-list/account-list.component.spec.ts
+++ b/library/src/app/components/account/account-list/account-list.component.spec.ts
@@ -127,7 +127,7 @@ describe('AccountListComponent', () => {
       const fiatAccount = processedAccounts[0];
 
       expect(fiatAccount.price).toBeUndefined();
-      expect(fiatAccount.value).toEqual(Number(fiatAccount.platform_available));
+      expect(fiatAccount.value).toBeUndefined();
     });
 
     it('should process crypto accounts', () => {

--- a/library/src/app/components/account/account-list/account-list.component.spec.ts
+++ b/library/src/app/components/account/account-list/account-list.component.spec.ts
@@ -10,11 +10,11 @@ import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MatSort } from '@angular/material/sort';
 
 import { HttpLoaderFactory } from '../../../modules/library.module';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { of, throwError } from 'rxjs';
-import { PageEvent } from '@angular/material/paginator';
 
 // Services
 import {
@@ -49,7 +49,7 @@ describe('AccountListComponent', () => {
   ]);
   let MockConfigService = jasmine.createSpyObj('ConfigService', ['getConfig$']);
   let MockAccountService = jasmine.createSpyObj('AccountService', [
-    'listAccounts'
+    'listAllAccounts'
   ]);
   let MockPriceService = jasmine.createSpyObj('PriceService', ['listPrices']);
   let MockRoutingService = jasmine.createSpyObj('RoutingService', [
@@ -88,13 +88,13 @@ describe('AccountListComponent', () => {
     }).compileComponents();
     MockEventService = TestBed.inject(EventService);
     MockErrorService = TestBed.inject(ErrorService);
-    MockAccountService = TestBed.inject(AccountService);
     MockPriceService = TestBed.inject(PriceService);
     MockRoutingService = TestBed.inject(RoutingService);
     MockConfigService = TestBed.inject(ConfigService);
     MockConfigService.getConfig$.and.returnValue(of(TestConstants.CONFIG));
-    MockAccountService.listAccounts.and.returnValue(
-      of(TestConstants.ACCOUNT_LIST_BANK_MODEL)
+    MockAccountService = TestBed.inject(AccountService);
+    MockAccountService.listAllAccounts.and.returnValue(
+      of(TestConstants.ACCOUNT_LIST_BANK_MODEL.objects)
     );
     MockPriceService.listPrices.and.returnValue(
       of(TestConstants.SYMBOL_PRICE_BANK_MODEL_ARRAY)
@@ -115,7 +115,7 @@ describe('AccountListComponent', () => {
 
   describe('when processing accounts', () => {
     it('should process fiat accounts', () => {
-      const accountList = { ...TestConstants.ACCOUNT_LIST_BANK_MODEL };
+      const accountList = [...TestConstants.ACCOUNT_LIST_BANK_MODEL.objects];
       const priceList = [...TestConstants.SYMBOL_PRICE_BANK_MODEL_ARRAY];
 
       const processedAccounts = component.processAccounts(
@@ -131,7 +131,7 @@ describe('AccountListComponent', () => {
     });
 
     it('should process crypto accounts', () => {
-      const accountList = { ...TestConstants.ACCOUNT_LIST_BANK_MODEL };
+      const accountList = [...TestConstants.ACCOUNT_LIST_BANK_MODEL.objects];
       const priceList = [...TestConstants.SYMBOL_PRICE_BANK_MODEL_ARRAY];
 
       const processedAccounts = component.processAccounts(
@@ -149,7 +149,7 @@ describe('AccountListComponent', () => {
 
   describe('when listing accounts', () => {
     it('should list accounts', () => {
-      expect(MockAccountService.listAccounts).toHaveBeenCalled();
+      expect(MockAccountService.listAllAccounts).toHaveBeenCalled();
     });
 
     it('should list prices', () => {
@@ -157,7 +157,7 @@ describe('AccountListComponent', () => {
     });
 
     it('should set the dataSource', () => {
-      const accountList = { ...TestConstants.ACCOUNT_LIST_BANK_MODEL };
+      const accountList = [...TestConstants.ACCOUNT_LIST_BANK_MODEL.objects];
       const priceList = [...TestConstants.SYMBOL_PRICE_BANK_MODEL_ARRAY];
 
       const processedAccounts = component.processAccounts(
@@ -168,25 +168,19 @@ describe('AccountListComponent', () => {
       expect(component.dataSource.data).toEqual(processedAccounts);
     });
 
-    it('should set the totalRows', () => {
-      const totalRows = Number(TestConstants.ACCOUNT_LIST_BANK_MODEL.total);
-
-      expect(component.totalRows).toEqual(totalRows);
-    });
-
     it('should handle errors when listing accounts', () => {
       const refreshDataSubSpy = spyOn(component.refreshDataSub, 'unsubscribe');
       const isRecoverable$Spy = spyOn(component.isRecoverable$, 'next');
 
-      MockAccountService.listAccounts.and.returnValue(error$);
+      MockAccountService.listAllAccounts.and.returnValue(error$);
 
-      component.listAccounts();
+      component.listAllAccounts();
 
       expect(refreshDataSubSpy).toHaveBeenCalled();
       expect(isRecoverable$Spy).toHaveBeenCalled();
 
       // Reset
-      MockAccountService.listAccounts.and.returnValue(
+      MockAccountService.listAllAccounts.and.returnValue(
         TestConstants.ACCOUNT_LIST_BANK_MODEL
       );
     });
@@ -197,7 +191,7 @@ describe('AccountListComponent', () => {
 
       MockPriceService.listPrices.and.returnValue(error$);
 
-      component.listAccounts();
+      component.listAllAccounts();
 
       expect(refreshDataSubSpy).toHaveBeenCalled();
       expect(isRecoverable$Spy).toHaveBeenCalled();
@@ -210,7 +204,7 @@ describe('AccountListComponent', () => {
   });
 
   it('should refresh data', fakeAsync(() => {
-    const listAccountsSpy = spyOn(component, 'listAccounts');
+    const listAccountsSpy = spyOn(component, 'listAllAccounts');
 
     component.refreshData();
     tick(Constants.REFRESH_INTERVAL);
@@ -246,61 +240,12 @@ describe('AccountListComponent', () => {
       let sort = component.sortingDataAccessor(account, '');
       expect(sort).toEqual('');
     });
-  });
+    it('should update the dataSource', () => {
+      const dataSourceSort = component.dataSource.sort;
 
-  describe('when paginating', () => {
-    beforeEach(() => {
-      // Mock listAccounts() to avoid Angular testing error
-      component.listAccounts = () => {};
+      component.sortChange();
+      expect(dataSourceSort).toBeUndefined();
     });
-
-    it('should update the current page', () => {
-      const pageIndex = 1;
-      const pageEvent: PageEvent = {
-        pageIndex: pageIndex,
-        pageSize: component.pageSize,
-        length: component.totalRows
-      };
-
-      component.pageChange(pageEvent);
-
-      expect(component.currentPage).toEqual(pageIndex);
-    });
-
-    it('should update the page size', () => {
-      const pageSize = 10;
-      const pageEvent: PageEvent = {
-        pageIndex: 0,
-        pageSize: pageSize,
-        length: component.totalRows
-      };
-
-      component.pageChange(pageEvent);
-
-      expect(component.pageSize).toEqual(pageSize);
-    });
-
-    it('should list accounts', () => {
-      const listAccountsSpy = spyOn(component, 'listAccounts');
-
-      const pageEvent: PageEvent = {
-        pageIndex: component.currentPage,
-        pageSize: component.pageSize,
-        length: component.totalRows
-      };
-
-      component.pageChange(pageEvent);
-
-      expect(listAccountsSpy).toHaveBeenCalled();
-    });
-  });
-
-  it('should sort', () => {
-    component.dataSource.sort = null;
-
-    component.sortChange();
-
-    expect(component.dataSource.sort).toBeDefined();
   });
 
   it('should navigate on row click', () => {

--- a/library/src/app/components/account/account-list/account-list.component.spec.ts
+++ b/library/src/app/components/account/account-list/account-list.component.spec.ts
@@ -127,7 +127,7 @@ describe('AccountListComponent', () => {
       const fiatAccount = processedAccounts[0];
 
       expect(fiatAccount.price).toBeUndefined();
-      expect(fiatAccount.value).toBeUndefined();
+      expect(fiatAccount.value).toBeDefined();
     });
 
     it('should process crypto accounts', () => {

--- a/library/src/app/components/account/account-list/account-list.component.ts
+++ b/library/src/app/components/account/account-list/account-list.component.ts
@@ -68,7 +68,7 @@ export class AccountListComponent
   getAccountsError = false;
 
   totalRows = 0;
-  pageSize = 5;
+  pageSize = 25;
   currentPage = 0;
   pageSizeOptions: number[] = [5, 10, 25, 100];
 
@@ -136,7 +136,7 @@ export class AccountListComponent
               'trade'
             )
           )
-        : Number(account.platform_available);
+        : undefined;
 
       processedAccounts.push(processedAccount);
     });

--- a/library/src/app/components/account/account-list/account-list.component.ts
+++ b/library/src/app/components/account/account-list/account-list.component.ts
@@ -128,16 +128,7 @@ export class AccountListComponent
             )
           );
       } else if (processedAccount.type == 'fiat') {
-        processedAccount.value =
-          // Convert to cents
-          100 *
-          Number(
-            this.assetFormatPipe.transform(
-              processedAccount.platform_available,
-              <string>account.asset,
-              'trade'
-            )
-          );
+        processedAccount.value = Number(processedAccount.platform_available);
       }
 
       processedAccounts.push(processedAccount);

--- a/library/src/app/components/account/account-list/account-list.component.ts
+++ b/library/src/app/components/account/account-list/account-list.component.ts
@@ -54,8 +54,7 @@ import { AssetFormatPipe } from '@pipes';
   styleUrls: ['./account-list.component.scss']
 })
 export class AccountListComponent
-  implements OnInit, AfterContentInit, OnDestroy
-{
+  implements OnInit, AfterContentInit, OnDestroy {
   @ViewChild(MatSort, { static: false }) sort!: MatSort;
   dataSource = new MatTableDataSource<AccountBankModelWithDetails>();
 
@@ -146,7 +145,6 @@ export class AccountListComponent
         .toString()
     );
 
-    console.log('processedAccounts', processedAccounts);
     return processedAccounts;
   }
 

--- a/library/src/app/components/account/account-list/account-list.component.ts
+++ b/library/src/app/components/account/account-list/account-list.component.ts
@@ -54,7 +54,8 @@ import { AssetFormatPipe } from '@pipes';
   styleUrls: ['./account-list.component.scss']
 })
 export class AccountListComponent
-  implements OnInit, AfterContentInit, OnDestroy {
+  implements OnInit, AfterContentInit, OnDestroy
+{
   @ViewChild(MatSort, { static: false }) sort!: MatSort;
   dataSource = new MatTableDataSource<AccountBankModelWithDetails>();
 

--- a/library/src/app/components/account/account-list/account-list.component.ts
+++ b/library/src/app/components/account/account-list/account-list.component.ts
@@ -82,7 +82,7 @@ export class AccountListComponent
     private accountService: AccountService,
     private routingService: RoutingService,
     private assetFormatPipe: AssetFormatPipe
-  ) {}
+  ) { }
 
   ngOnInit(): void {
     this.eventService.handleEvent(
@@ -116,16 +116,25 @@ export class AccountListComponent
         return account.asset === price.symbol?.split('-')[0];
       });
 
-      processedAccount.value = processedAccount.price
-        ? Number(processedAccount.price.sell_price) *
-        Number(
+      if (processedAccount.price) {
+        processedAccount.value =
+          Number(processedAccount.price.sell_price) *
+          Number(
+            this.assetFormatPipe.transform(
+              account.platform_balance,
+              <string>account.asset,
+              'trade'
+            )
+          );
+      } else if (processedAccount.type == 'fiat') {
+        processedAccount.value = Number(
           this.assetFormatPipe.transform(
-            account.platform_balance,
+            processedAccount.platform_available,
             <string>account.asset,
             'trade'
           )
-        )
-        : undefined;
+        );
+      }
 
       processedAccounts.push(processedAccount);
     });
@@ -136,6 +145,7 @@ export class AccountListComponent
         .toString()
     );
 
+    console.log('processedAccounts', processedAccounts);
     return processedAccounts;
   }
 

--- a/library/src/app/components/account/account-list/account-list.component.ts
+++ b/library/src/app/components/account/account-list/account-list.component.ts
@@ -54,7 +54,8 @@ import { AssetFormatPipe } from '@pipes';
   styleUrls: ['./account-list.component.scss']
 })
 export class AccountListComponent
-  implements OnInit, AfterContentInit, OnDestroy {
+  implements OnInit, AfterContentInit, OnDestroy
+{
   @ViewChild(MatSort, { static: false }) sort!: MatSort;
   dataSource = new MatTableDataSource<AccountBankModelWithDetails>();
 
@@ -82,7 +83,7 @@ export class AccountListComponent
     private accountService: AccountService,
     private routingService: RoutingService,
     private assetFormatPipe: AssetFormatPipe
-  ) { }
+  ) {}
 
   ngOnInit(): void {
     this.eventService.handleEvent(

--- a/library/src/app/components/account/account-list/account-list.component.ts
+++ b/library/src/app/components/account/account-list/account-list.component.ts
@@ -128,13 +128,16 @@ export class AccountListComponent
             )
           );
       } else if (processedAccount.type == 'fiat') {
-        processedAccount.value = Number(
-          this.assetFormatPipe.transform(
-            processedAccount.platform_available,
-            <string>account.asset,
-            'trade'
-          )
-        );
+        processedAccount.value =
+          // Convert to cents
+          100 *
+          Number(
+            this.assetFormatPipe.transform(
+              processedAccount.platform_available,
+              <string>account.asset,
+              'trade'
+            )
+          );
       }
 
       processedAccounts.push(processedAccount);

--- a/library/src/shared/constants/test.constants.ts
+++ b/library/src/shared/constants/test.constants.ts
@@ -194,7 +194,7 @@ export class TestConstants {
   ];
 
   static ACCOUNT_LIST_BANK_MODEL: AccountListBankModel = {
-    total: '4',
+    total: '5',
     page: '0',
     per_page: '10',
     objects: [

--- a/library/src/shared/services/account/account.service.spec.ts
+++ b/library/src/shared/services/account/account.service.spec.ts
@@ -4,7 +4,7 @@ import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { HttpLoaderFactory } from '../../../app/modules/library.module';
 import { HttpClient } from '@angular/common/http';
 
-import { of, throwError } from 'rxjs';
+import { EMPTY, of, throwError } from 'rxjs';
 
 // Client
 import {
@@ -99,6 +99,57 @@ describe('AccountService', () => {
       MockAccountsService.listAccounts.and.returnValue(error$);
 
       service.listAccounts().subscribe(() => {
+        expect(MockErrorService.handleError).toHaveBeenCalled();
+        expect(MockEventService.handleEvent).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when paging all accounts', () => {
+    it('should page accounts', () => {
+      const perPage = Number(TestConstants.ACCOUNT_LIST_BANK_MODEL.total);
+      service.pageAccounts(perPage, TestConstants.ACCOUNT_LIST_BANK_MODEL);
+
+      expect(MockAccountsService.listAccounts).toHaveBeenCalled();
+    });
+
+    it('should return EMPTY when complete', () => {
+      const perPage = Number(TestConstants.ACCOUNT_LIST_BANK_MODEL.total + 1);
+      const accounts = service.pageAccounts(
+        perPage,
+        TestConstants.ACCOUNT_LIST_BANK_MODEL
+      );
+
+      expect(accounts).toEqual(EMPTY);
+    });
+
+    it('should accumulate accounts', () => {
+      const totalAccounts =
+        Number(TestConstants.ACCOUNT_LIST_BANK_MODEL.total) + 1;
+      const accounts = service.accumulateAccounts(
+        TestConstants.ACCOUNT_LIST_BANK_MODEL.objects,
+        [TestConstants.ACCOUNT_LIST_BANK_MODEL.objects[0]]
+      );
+
+      expect(accounts.length).toEqual(totalAccounts);
+    });
+  });
+
+  describe('when listing all accounts', () => {
+    it('should list all accounts', () => {
+      service.accountsPerPage = Number(
+        TestConstants.ACCOUNT_LIST_BANK_MODEL.total
+      );
+
+      service.listAllAccounts().subscribe((accounts: AccountBankModel[]) => {
+        expect(TestConstants.ACCOUNT_LIST_BANK_MODEL.objects).toEqual(accounts);
+      });
+    });
+
+    it('should handle errors', () => {
+      MockAccountsService.listAccounts.and.returnValue(error$);
+
+      service.listAllAccounts().subscribe(() => {
         expect(MockErrorService.handleError).toHaveBeenCalled();
         expect(MockEventService.handleEvent).toHaveBeenCalled();
       });

--- a/library/src/shared/services/account/account.service.ts
+++ b/library/src/shared/services/account/account.service.ts
@@ -69,9 +69,9 @@ export class AccountService implements OnDestroy {
   pageAccounts(perPage: number, list: AccountListBankModel) {
     return list.objects.length == perPage
       ? this.accountsService.listAccounts(
-        (Number(list.page) + 1).toString(),
-        perPage.toString()
-      )
+          (Number(list.page) + 1).toString(),
+          perPage.toString()
+        )
       : EMPTY;
   }
 

--- a/library/src/shared/services/account/account.service.ts
+++ b/library/src/shared/services/account/account.service.ts
@@ -1,5 +1,15 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { Observable, Subject, catchError, of } from 'rxjs';
+import {
+  catchError,
+  EMPTY,
+  expand,
+  map,
+  tap,
+  Observable,
+  of,
+  reduce,
+  Subject
+} from 'rxjs';
 
 // Client
 import {
@@ -22,6 +32,8 @@ export interface AccountBankModelWithDetails extends AccountBankModel {
 })
 export class AccountService implements OnDestroy {
   private unsubscribe$ = new Subject();
+
+  accountsPerPage = 10;
 
   constructor(
     private eventService: EventService,
@@ -48,6 +60,39 @@ export class AccountService implements OnDestroy {
 
         this.errorService.handleError(
           new Error('There was an error listing accounts')
+        );
+        return of(err);
+      })
+    );
+  }
+
+  pageAccounts(perPage: number, list: AccountListBankModel) {
+    return list.objects.length == perPage
+      ? this.accountsService.listAccounts(
+        (Number(list.page) + 1).toString(),
+        perPage.toString()
+      )
+      : EMPTY;
+  }
+
+  accumulateAccounts(acc: AccountBankModel[], value: AccountBankModel[]) {
+    return [...acc, ...value];
+  }
+
+  listAllAccounts(): Observable<AccountBankModel[]> {
+    return this.accountsService.listAccounts().pipe(
+      expand((list) => this.pageAccounts(this.accountsPerPage, list)),
+      map((list) => list.objects),
+      reduce((acc, value) => this.accumulateAccounts(acc, value)),
+      catchError((err) => {
+        this.eventService.handleEvent(
+          LEVEL.ERROR,
+          CODE.DATA_ERROR,
+          'There was an error listing all accounts'
+        );
+
+        this.errorService.handleError(
+          new Error('There was an error listing all accounts')
         );
         return of(err);
       })

--- a/library/src/shared/services/asset/asset.service.spec.ts
+++ b/library/src/shared/services/asset/asset.service.spec.ts
@@ -104,7 +104,7 @@ describe('AssetService', () => {
     MockAssetsService.listAssets.and.returnValue(of(assetList));
 
     assetService.listAssets();
-    expect(assetService.pageExternalAccounts(assetList)).toBeInstanceOf(
+    expect(assetService.pageAssets(assetList)).toBeInstanceOf(
       Observable<AssetListBankModel>
     );
   });

--- a/library/src/shared/services/asset/asset.service.ts
+++ b/library/src/shared/services/asset/asset.service.ts
@@ -49,7 +49,7 @@ export class AssetService {
     this.initAssets();
   }
 
-  pageExternalAccounts(
+  pageAssets(
     list: AssetListBankModel
   ): Observable<AssetListBankModel> | Observable<never> {
     return list.objects.length == Number(list.per_page)
@@ -66,7 +66,7 @@ export class AssetService {
 
   listAssets(): Observable<AssetBankModel[]> {
     return this.assetsService.listAssets().pipe(
-      expand((list) => this.pageExternalAccounts(list)),
+      expand((list) => this.pageAssets(list)),
       map((list) => list.objects),
       reduce((acc, value) => this.accumulateAssets(acc, value))
     );


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [x] Bug fix

### Linked issue
https://cybrid.atlassian.net/browse/CYB-1696

### Why
Processing trading accounts that have no associated price leads the template to display the incorrect value.

### How
Ensure the value is undefined and do not show in the template.
Also: Page through all accounts and remove the paginator. The total account value now includes all accounts.