### PR TITLE
fix: pending persona state

### DIFF
--- a/library/src/app/components/identity-verification/identity-verification.component.spec.ts
+++ b/library/src/app/components/identity-verification/identity-verification.component.spec.ts
@@ -26,6 +26,8 @@ import { IdentityVerificationComponent } from '@components';
 import { TestConstants } from '@constants';
 import { SharedModule } from '../../../shared/modules/shared.module';
 
+import { IdentityVerificationWithDetailsBankModel } from '@cybrid/cybrid-api-bank-angular';
+
 describe('IdentityVerificationComponent', () => {
   let component: IdentityVerificationComponent;
   let fixture: ComponentFixture<IdentityVerificationComponent>;
@@ -221,15 +223,98 @@ describe('IdentityVerificationComponent', () => {
   });
 
   describe('with existing identity verifications', () => {
-    describe('with expired state', () => {
-      it('should create an identity verification', fakeAsync(() => {
-        let identityVerificationListBankModel = {
-          ...TestConstants.IDENTITY_VERIFICATION_LIST_BANK_MODEL
-        };
-        identityVerificationListBankModel.objects[0].state = 'expired';
+    describe('with waiting persona_state', () => {
+      describe('with expired state', () => {
+        it('should create an identity verification', fakeAsync(() => {
+          let identityVerificationListBankModel = {
+            ...TestConstants.IDENTITY_VERIFICATION_LIST_BANK_MODEL
+          };
+          identityVerificationListBankModel.objects[0].state = 'expired';
 
-        MockIdentityVerificationService.listIdentityVerifications.and.returnValue(
-          of(identityVerificationListBankModel)
+          MockIdentityVerificationService.listIdentityVerifications.and.returnValue(
+            of(identityVerificationListBankModel)
+          );
+
+          component.verifyIdentity();
+
+          tick();
+          expect(
+            MockIdentityVerificationService.createIdentityVerification
+          ).toHaveBeenCalled();
+
+          discardPeriodicTasks();
+
+          // Reset
+          MockIdentityVerificationService.listIdentityVerifications.and.returnValue(
+            of(TestConstants.IDENTITY_VERIFICATION_LIST_BANK_MODEL)
+          );
+        }));
+      });
+
+      describe('with completed state', () => {
+        it('should create an identity verification', fakeAsync(() => {
+          let identityVerificationListBankModel = {
+            ...TestConstants.IDENTITY_VERIFICATION_LIST_BANK_MODEL
+          };
+          identityVerificationListBankModel.objects[0].state = 'completed';
+
+          MockIdentityVerificationService.listIdentityVerifications.and.returnValue(
+            of(identityVerificationListBankModel)
+          );
+
+          component.verifyIdentity();
+
+          tick();
+          expect(
+            MockIdentityVerificationService.createIdentityVerification
+          ).toHaveBeenCalled();
+
+          discardPeriodicTasks();
+
+          // Reset
+          MockIdentityVerificationService.listIdentityVerifications.and.returnValue(
+            of(TestConstants.IDENTITY_VERIFICATION_LIST_BANK_MODEL)
+          );
+        }));
+      });
+
+      describe('with storing state', () => {
+        it('should get the identity verification', fakeAsync(() => {
+          component.verifyIdentity();
+
+          tick();
+          expect(
+            MockIdentityVerificationService.getIdentityVerification
+          ).toHaveBeenCalled();
+
+          discardPeriodicTasks();
+        }));
+      });
+
+      describe('with waiting state', () => {
+        it('should get the identity verification', fakeAsync(() => {
+          component.verifyIdentity();
+
+          tick();
+          expect(
+            MockIdentityVerificationService.getIdentityVerification
+          ).toHaveBeenCalled();
+
+          discardPeriodicTasks();
+        }));
+      });
+    });
+
+    describe('with pending persona_state', () => {
+      it('should create an identity verification', fakeAsync(() => {
+        let identityVerificationBankModel = {
+          ...TestConstants.IDENTITY_VERIFICATION_BANK_MODEL
+        };
+        identityVerificationBankModel.persona_state =
+          IdentityVerificationWithDetailsBankModel.PersonaStateEnum.Pending;
+
+        MockIdentityVerificationService.getIdentityVerification.and.returnValue(
+          of(identityVerificationBankModel)
         );
 
         component.verifyIdentity();
@@ -242,62 +327,9 @@ describe('IdentityVerificationComponent', () => {
         discardPeriodicTasks();
 
         // Reset
-        MockIdentityVerificationService.listIdentityVerifications.and.returnValue(
-          of(TestConstants.IDENTITY_VERIFICATION_LIST_BANK_MODEL)
+        MockIdentityVerificationService.getIdentityVerification.and.returnValue(
+          of(TestConstants.IDENTITY_VERIFICATION_BANK_MODEL)
         );
-      }));
-    });
-
-    describe('with completed state', () => {
-      it('should create an identity verification', fakeAsync(() => {
-        let identityVerificationListBankModel = {
-          ...TestConstants.IDENTITY_VERIFICATION_LIST_BANK_MODEL
-        };
-        identityVerificationListBankModel.objects[0].state = 'completed';
-
-        MockIdentityVerificationService.listIdentityVerifications.and.returnValue(
-          of(identityVerificationListBankModel)
-        );
-
-        component.verifyIdentity();
-
-        tick();
-        expect(
-          MockIdentityVerificationService.createIdentityVerification
-        ).toHaveBeenCalled();
-
-        discardPeriodicTasks();
-
-        // Reset
-        MockIdentityVerificationService.listIdentityVerifications.and.returnValue(
-          of(TestConstants.IDENTITY_VERIFICATION_LIST_BANK_MODEL)
-        );
-      }));
-    });
-
-    describe('with storing state', () => {
-      it('should get the identity verification', fakeAsync(() => {
-        component.verifyIdentity();
-
-        tick();
-        expect(
-          MockIdentityVerificationService.getIdentityVerification
-        ).toHaveBeenCalled();
-
-        discardPeriodicTasks();
-      }));
-    });
-
-    describe('with waiting state', () => {
-      it('should get the identity verification', fakeAsync(() => {
-        component.verifyIdentity();
-
-        tick();
-        expect(
-          MockIdentityVerificationService.getIdentityVerification
-        ).toHaveBeenCalled();
-
-        discardPeriodicTasks();
       }));
     });
   });

--- a/library/src/app/components/identity-verification/identity-verification.component.ts
+++ b/library/src/app/components/identity-verification/identity-verification.component.ts
@@ -187,6 +187,17 @@ export class IdentityVerificationComponent implements OnInit, OnDestroy {
             ? of(identity)
             : this.identityVerificationService.createIdentityVerification();
         }),
+        switchMap((identity) =>
+          this.identityVerificationService.getIdentityVerification(
+            <string>identity.guid
+          )
+        ),
+        switchMap((identity) => {
+          return identity.persona_state ===
+            IdentityVerificationWithDetailsBankModel.PersonaStateEnum.Waiting
+            ? of(identity)
+            : this.identityVerificationService.createIdentityVerification();
+        }),
         tap((identity) => {
           this.identityVerificationGuid = identity.guid;
         }),
@@ -260,7 +271,8 @@ export class IdentityVerificationComponent implements OnInit, OnDestroy {
           this.bootstrapPersona(identity.persona_inquiry_id!);
           break;
         case 'pending':
-          this.bootstrapPersona(identity.persona_inquiry_id!);
+          this.isLoading$.next(false);
+          this.identity$.next(identity);
           break;
         case 'reviewing':
           this.isLoading$.next(false);


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [x] Bug fix

### Linked issue
https://cybrid.atlassian.net/browse/CYB-1746

### Why
We want to handle an IDV `persona_state: pending` by creating a new IDV. This will help to reduce session resume errors.

### How
By adding a check for the`persona_state`