### PR TITLE
fix: persona review state

### DIFF
--- a/library/src/app/components/identity-verification/identity-verification.component.ts
+++ b/library/src/app/components/identity-verification/identity-verification.component.ts
@@ -203,7 +203,10 @@ export class IdentityVerificationComponent implements OnInit, OnDestroy {
         ),
         switchMap((identity) => {
           return identity.persona_state ===
-            IdentityVerificationWithDetailsBankModel.PersonaStateEnum.Waiting
+            IdentityVerificationWithDetailsBankModel.PersonaStateEnum.Waiting ||
+            identity.persona_state ===
+              IdentityVerificationWithDetailsBankModel.PersonaStateEnum
+                .Reviewing
             ? of(identity)
             : this.identityVerificationService.createIdentityVerification();
         }),
@@ -219,7 +222,7 @@ export class IdentityVerificationComponent implements OnInit, OnDestroy {
         takeUntil(merge(poll.session$, this.unsubscribe$)),
         skipWhile(
           (identity) =>
-            identity.state == IdentityVerificationBankModel.StateEnum.Storing
+            identity.state === IdentityVerificationBankModel.StateEnum.Storing
         ),
         tap((identity) => {
           poll.stop();


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [x] Bug fix

### Linked issue
https://cybrid.atlassian.net/browse/CYB-1822

### Why
Partner should not be able to create a new verification if an existing verification is in "needs review".

### How
Added a check for `persona_state: 'reviewing'`. Did some test cleanup around `state` and `persona_state`.