### PR TITLE
fix: Persona state handling

### DIFF
--- a/library/src/app/components/identity-verification/identity-verification.component.spec.ts
+++ b/library/src/app/components/identity-verification/identity-verification.component.spec.ts
@@ -505,7 +505,7 @@ describe('IdentityVerificationComponent', () => {
 
         expect(
           MockIdentityVerificationService.createIdentityVerification
-        ).not.toHaveBeenCalled();
+        ).toHaveBeenCalled();
       });
     });
 

--- a/library/src/app/components/identity-verification/identity-verification.component.ts
+++ b/library/src/app/components/identity-verification/identity-verification.component.ts
@@ -88,8 +88,7 @@ export class IdentityVerificationComponent implements OnInit, OnDestroy {
   validPersonaState = [
     IdentityVerificationWithDetails.PersonaStateEnum.Waiting,
     IdentityVerificationWithDetails.PersonaStateEnum.Reviewing,
-    IdentityVerificationWithDetails.PersonaStateEnum.Processing,
-    IdentityVerificationWithDetails.PersonaStateEnum.Completed
+    IdentityVerificationWithDetails.PersonaStateEnum.Processing
   ];
 
   constructor(


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [ ] Bug fix

### Linked issue
https://cybrid.atlassian.net/browse/CYB-1958

### Why
`persona_state: completed` is handled as a valid state and a new inquiry is not created. If we are checking Persona states it's because the customer is `unverified` and we need a new inquiry to start here.

### How
By removing `persona_state: completed` from the list of valid states.