### PR TITLE
fix: transfer account selector

### DIFF
--- a/library/src/app/components/transfer/transfer.component.html
+++ b/library/src/app/components/transfer/transfer.component.html
@@ -1,133 +1,113 @@
-<ng-container *ngIf="(isLoading$ | async) !== true; else loading">
-  <ng-container
-    *ngIf="{
-      fiatAccount: fiatAccount$ | async,
-      bankAccounts: bankAccounts$ | async
-    } as accounts"
-  >
-    <ng-container *ngIf="configService.getConfig$() | async as config">
-      <app-navigation [routingData]="routingData"></app-navigation>
-      <ng-container *ngIf="accounts.bankAccounts!.length > 0; else noAccount">
-        <app-account-balance
-          [account]="accounts.fiatAccount"
-        ></app-account-balance>
-        <mat-tab-group
-          animationDuration="0ms"
-          (selectedTabChange)="onSwitchSide($event.tab.origin)"
-        >
-          <mat-tab
-            label="{{ 'transfer.deposit' | translate | uppercase }}"
-          ></mat-tab>
-          <mat-tab
-            label="{{ 'transfer.withdraw' | translate | uppercase }}"
-          ></mat-tab>
-        </mat-tab-group>
-        <ng-container [formGroup]="transferGroup">
-          <div class="cybrid-tabs">
-            <div class="cybrid-input-wrapper">
-              <div class="cybrid-input-flex">
-                <label class="mat-hint cybrid-h5">{{
-                  'transfer.bankAccount' | translate
-                }}</label>
-                <mat-form-field appearance="outline">
-                  <mat-select #account formControlName="account">
-                    <mat-select-trigger>
-                      <div class="cybrid-option">
-                        <mat-icon>savings</mat-icon>
-                        <span class="cybrid-trigger-name">
-                          <strong>{{
-                            account.value.plaid_institution_id + ' - '
-                          }}</strong>
-                          <span>{{ account.value.plaid_account_name }}</span>
-                          <span class="mat-hint">{{
-                            ' (' + account.value.plaid_account_mask + ')'
-                          }}</span>
-                        </span>
-                      </div>
-                    </mat-select-trigger>
-                    <mat-option
-                      *ngFor="let account of accounts.bankAccounts"
-                      [value]="account"
-                    >
-                      <div class="cybrid-option">
-                        <mat-icon>savings</mat-icon>
-                        <div>
-                          <span>{{
-                            account.plaid_institution_id + ' - '
-                          }}</span>
-                          <span>{{ account.plaid_account_name + ' ' }}</span>
-                          <span>{{
-                            '(' + account.plaid_account_mask + ')'
-                          }}</span>
+<ng-container *ngIf="(isRecoverable$ | async) !== false; else error">
+  <ng-container *ngIf="(isLoading$ | async) !== true; else loading">
+    <ng-container *ngIf="{
+        fiatAccount: fiatAccount$ | async,
+        externalBankAccounts: externalBankAccounts$ | async
+      } as accounts">
+      <ng-container *ngIf="configService.getConfig$() | async as config">
+        <app-navigation [routingData]="routingData"></app-navigation>
+        <ng-container *ngIf="accounts.externalBankAccounts!.length > 0; else noAccount">
+          <app-account-balance [account]="accounts.fiatAccount"></app-account-balance>
+          <mat-tab-group animationDuration="0ms" (selectedTabChange)="onSwitchSide($event.tab.origin)">
+            <mat-tab label="{{ 'transfer.deposit' | translate | uppercase }}"></mat-tab>
+            <mat-tab label="{{ 'transfer.withdraw' | translate | uppercase }}"></mat-tab>
+          </mat-tab-group>
+          <ng-container [formGroup]="transferGroup">
+            <div class="cybrid-tabs">
+              <div class="cybrid-input-wrapper">
+                <div class="cybrid-input-flex">
+                  <label class="mat-hint cybrid-h5">{{
+                    'transfer.bankAccount' | translate
+                    }}</label>
+                  <mat-form-field appearance="outline">
+                    <mat-select #account formControlName="account">
+                      <mat-select-trigger>
+                        <div class="cybrid-option">
+                          <mat-icon>savings</mat-icon>
+                          <span class="cybrid-trigger-name">
+                            <strong>{{
+                              account.value.plaid_institution_id + ' - '
+                              }}</strong>
+                            <span>{{ account.value.plaid_account_name }}</span>
+                            <span class="mat-hint">{{
+                              ' (' + account.value.plaid_account_mask + ')'
+                              }}</span>
+                          </span>
                         </div>
-                      </div>
-                    </mat-option>
-                  </mat-select>
-                </mat-form-field>
-              </div>
-              <div class="cybrid-input-flex">
-                <label class="mat-hint cybrid-h5">{{
-                  'transfer.amount' | translate
-                }}</label>
-                <mat-form-field appearance="outline">
-                  <input
-                    matInput
-                    id="amount"
-                    [ngClass]="{ 'cybrid-amount-input': amount.value }"
-                    #amount="matInput"
-                    formControlName="amount"
-                    type="number"
-                    min="0"
-                    placeholder="0.00"
-                    step=".01"
-                  />
-                  <div *ngIf="amount.value" class="cybrid-prefix" matPrefix>
-                    {{ account.value.asset }}
-                    <div class="cybrid-amount-divider"></div>
-                  </div>
-                  <mat-error
-                    *ngIf="
-                      transferGroup.controls.amount.hasError(
-                        'nonSufficientFunds'
-                      )
-                    "
-                  >
-                    {{ 'transfer.nonSufficientFunds' | translate }}
-                  </mat-error>
-                </mat-form-field>
+                      </mat-select-trigger>
+                      <mat-option *ngFor="let account of accounts.externalBankAccounts" [value]="account">
+                        <div class="cybrid-option">
+                          <mat-icon>savings</mat-icon>
+                          <div>
+                            <span>{{
+                              account.plaid_institution_id + ' - '
+                              }}</span>
+                            <span>{{ account.plaid_account_name + ' ' }}</span>
+                            <span>{{
+                              '(' + account.plaid_account_mask + ')'
+                              }}</span>
+                          </div>
+                        </div>
+                      </mat-option>
+                    </mat-select>
+                  </mat-form-field>
+                </div>
+                <div class="cybrid-input-flex">
+                  <label class="mat-hint cybrid-h5">{{
+                    'transfer.amount' | translate
+                    }}</label>
+                  <mat-form-field appearance="outline">
+                    <input matInput id="amount" [ngClass]="{ 'cybrid-amount-input': amount.value }" #amount="matInput"
+                      formControlName="amount" type="number" min="0" placeholder="0.00" step=".01" />
+                    <div *ngIf="amount.value" class="cybrid-prefix" matPrefix>
+                      {{ account.value.asset }}
+                      <div class="cybrid-amount-divider"></div>
+                    </div>
+                    <mat-error *ngIf="
+                        transferGroup.controls.amount.hasError(
+                          'nonSufficientFunds'
+                        )
+                      ">
+                      {{ 'transfer.nonSufficientFunds' | translate }}
+                    </mat-error>
+                  </mat-form-field>
+                </div>
               </div>
             </div>
-          </div>
-          <div class="cybrid-actions">
-            <button
-              id="action"
-              mat-flat-button
-              color="primary"
-              (click)="onTransfer()"
-              [disabled]="
-                transferGroup.invalid || (isCreatingTransfer$ | async)
-              "
-            >
-              {{
+            <div class="cybrid-actions">
+              <button id="action" mat-flat-button color="primary" (click)="onTransfer()" [disabled]="
+                  transferGroup.invalid || (isCreatingTransfer$ | async)
+                ">
+                {{
                 side === 'deposit'
-                  ? ('transfer.deposit' | translate | uppercase)
-                  : ('transfer.withdraw' | translate | uppercase)
-              }}
+                ? ('transfer.deposit' | translate | uppercase)
+                : ('transfer.withdraw' | translate | uppercase)
+                }}
+              </button>
+            </div>
+          </ng-container>
+        </ng-container>
+        <ng-template #noAccount>
+          <div class="cybrid-column cybrid-no-accounts">
+            <p>{{ 'transfer.noAccount' | translate }}</p>
+            <button mat-flat-button color="primary" (click)="onAddAccount()">
+              {{ 'transfer.addAccount' | translate }}
             </button>
           </div>
-        </ng-container>
+        </ng-template>
       </ng-container>
-      <ng-template #noAccount>
-        <div class="cybrid-column cybrid-no-accounts">
-          <p>{{ 'transfer.noAccount' | translate }}</p>
-          <button mat-flat-button color="primary" (click)="onAddAccount()">
-            {{ 'transfer.addAccount' | translate }}
-          </button>
-        </div>
-      </ng-template>
     </ng-container>
   </ng-container>
 </ng-container>
 <ng-template #loading>
   <app-loading></app-loading>
+</ng-template>
+<ng-template #error>
+  <mat-card>
+    <mat-card-content>
+      <div class="fatal">
+        <p>{{ 'fatal' | translate }}</p>
+      </div>
+    </mat-card-content>
+  </mat-card>
 </ng-template>

--- a/library/src/app/components/transfer/transfer.component.spec.ts
+++ b/library/src/app/components/transfer/transfer.component.spec.ts
@@ -13,7 +13,7 @@ import { HttpClient } from '@angular/common/http';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 
-import { Observable, of, throwError } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 // Services
 import {
@@ -25,10 +25,8 @@ import {
   RoutingService,
   AccountService
 } from '@services';
-import {
-  ExternalBankAccountListBankModel,
-  QuotesService
-} from '@cybrid/cybrid-api-bank-angular';
+
+import { QuotesService } from '@cybrid/cybrid-api-bank-angular';
 
 // Components
 import { TransferComponent } from '@components';
@@ -194,63 +192,20 @@ describe('TransferComponent', () => {
     expect(component.side).toEqual('withdrawal');
   });
 
-  it('should page through external bank accounts', () => {
-    let externalBankAccountList = {
-      ...TestConstants.EXTERNAL_BANK_ACCOUNT_LIST_BANK_MODEL
-    };
-    externalBankAccountList.objects = [];
-
-    // Fill objects with amount per page
-    for (let i = 0; i < component.externalBankAccountsPerPage; i++) {
-      externalBankAccountList.objects.push(
-        TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL
-      );
-    }
-
-    MockBankAccountService.listExternalBankAccounts.and.returnValue(
-      of(externalBankAccountList)
-    );
-
-    component.listAccounts();
-    expect(
-      component.pageExternalAccounts(
-        component.externalBankAccountsPerPage,
-        externalBankAccountList
-      )
-    ).toBeInstanceOf(Observable<ExternalBankAccountListBankModel>);
-
-    // Reset
-    MockBankAccountService.listExternalBankAccounts.and.returnValue(
-      of(TestConstants.EXTERNAL_BANK_ACCOUNT_LIST_BANK_MODEL)
-    );
-  });
-
-  it('should accumulate external accounts', () => {
-    expect(
-      component.accumulateExternalAccounts(
-        [{ ...TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL }],
-        [{ ...TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL }]
-      )
-    ).toEqual([
-      ...[{ ...TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL }],
-      ...[{ ...TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL }]
-    ]);
-  });
-
   it('should handle an error on listExternalBankAccounts()', () => {
+    const isRecoverable$Spy = spyOn(component.isRecoverable$, 'next');
     MockBankAccountService.listExternalBankAccounts.and.returnValue(error$);
 
-    component.listAccounts();
-    expect(MockErrorService.handleError).toHaveBeenCalled();
-    expect(MockEventService.handleEvent).toHaveBeenCalled();
+    component.listExternalBankAccounts();
+    expect(isRecoverable$Spy).toHaveBeenCalledWith(false);
   });
 
-  it('should handle an error on listAccounts()', () => {
+  it('should handle an error on getFiatAccount()', () => {
+    const isRecoverable$Spy = spyOn(component.isRecoverable$, 'next');
     MockAccountService.listAccounts.and.returnValue(error$);
 
-    component.listAccounts();
-    expect(MockErrorService.handleError).toHaveBeenCalled();
-    expect(MockEventService.handleEvent).toHaveBeenCalled();
+    component.getFiatAccount();
+    expect(isRecoverable$Spy).toHaveBeenCalledWith(false);
   });
 
   it('should create a quote onTransfer()', () => {

--- a/library/src/app/components/transfer/transfer.component.ts
+++ b/library/src/app/components/transfer/transfer.component.ts
@@ -102,7 +102,7 @@ export class TransferComponent implements OnInit, OnDestroy {
     private router: RoutingService,
     private dialog: MatDialog,
     private snackbar: MatSnackBar
-  ) { }
+  ) {}
 
   ngOnInit(): void {
     this.initTransferGroup();

--- a/library/src/app/components/transfer/transfer.component.ts
+++ b/library/src/app/components/transfer/transfer.component.ts
@@ -102,7 +102,7 @@ export class TransferComponent implements OnInit, OnDestroy {
     private router: RoutingService,
     private dialog: MatDialog,
     private snackbar: MatSnackBar
-  ) {}
+  ) { }
 
   ngOnInit(): void {
     this.initTransferGroup();
@@ -110,7 +110,10 @@ export class TransferComponent implements OnInit, OnDestroy {
     this.listExternalBankAccounts();
 
     combineLatest([this.fiatAccount$, this.externalBankAccounts$])
-      .pipe(tap(() => this.isLoading$.next(false)))
+      .pipe(
+        take(1),
+        tap(() => this.isLoading$.next(false))
+      )
       .subscribe();
   }
 

--- a/library/src/shared/constants/constants.ts
+++ b/library/src/shared/constants/constants.ts
@@ -25,7 +25,7 @@ export class Constants {
   static ROUTING = true;
   static ICON_HOST = 'https://images.cybrid.xyz/sdk/assets/svg/color/';
   static PERSONA_SCRIPT_SRC =
-    'https://cdn.withpersona.com/dist/persona-v4.11.0.js';
+    'https://cdn.withpersona.com/dist/persona-v4.12.0.js';
   static PLAID_SCRIPT_SRC =
     'https://cdn.plaid.com/link/v2/stable/link-initialize.js';
   static BTC_ICON = 'https://images.cybrid.xyz/sdk/assets/svg/color/btc.svg';

--- a/library/src/shared/services/account/account.service.ts
+++ b/library/src/shared/services/account/account.service.ts
@@ -4,8 +4,6 @@ import {
   EMPTY,
   expand,
   map,
-  tap,
-  throwError,
   Observable,
   of,
   reduce,
@@ -49,22 +47,27 @@ export class AccountService implements OnDestroy {
 
   listAccounts(
     page?: string,
-    perPage?: string
+    perPage?: string,
+    owner?: string,
+    guid?: string,
+    type?: string
   ): Observable<AccountListBankModel> {
-    return this.accountsService.listAccounts(page, perPage).pipe(
-      catchError((err) => {
-        this.eventService.handleEvent(
-          LEVEL.ERROR,
-          CODE.DATA_ERROR,
-          'There was an error listing accounts'
-        );
+    return this.accountsService
+      .listAccounts(page, perPage, owner, guid, type)
+      .pipe(
+        catchError((err) => {
+          this.eventService.handleEvent(
+            LEVEL.ERROR,
+            CODE.DATA_ERROR,
+            'There was an error listing accounts'
+          );
 
-        this.errorService.handleError(
-          new Error('There was an error listing accounts')
-        );
-        return of(err);
-      })
-    );
+          this.errorService.handleError(
+            new Error('There was an error listing accounts')
+          );
+          return of(err);
+        })
+      );
   }
 
   pageAccounts(perPage: number, list: AccountListBankModel) {


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [x] Bug fix

### Linked issue
https://cybrid.atlassian.net/browse/CYB-1901

### Why
We are refreshing the external bank account list. When this happens the selected choice is reset. We don't need to refresh the external account list, only the fiat account so that we can validate the amount on withdrawal.

### How
By no longer polling on external bank accounts. Also refactored to utilize the `accountService` and `externalBankAccountService` for internal error handling.