### PR TITLE
fix: bank account reconnect

### DIFF
--- a/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.ts
+++ b/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.ts
@@ -187,11 +187,8 @@ export class BankAccountConnectComponent implements OnInit {
             externalBankAccountGuid ?? params['externalBankAccountGuid'];
           this.externalBankAccountGuid = guid;
 
-          return externalBankAccountGuid
-            ? this.createWorkflow(
-                PostWorkflowBankModel.KindEnum.Update,
-                externalBankAccountGuid
-              )
+          return guid
+            ? this.createWorkflow(PostWorkflowBankModel.KindEnum.Update, guid)
             : this.createWorkflow(PostWorkflowBankModel.KindEnum.Create);
         }),
         map((workflow) => {

--- a/library/src/shared/constants/constants.ts
+++ b/library/src/shared/constants/constants.ts
@@ -25,7 +25,7 @@ export class Constants {
   static ROUTING = true;
   static ICON_HOST = 'https://images.cybrid.xyz/sdk/assets/svg/color/';
   static PERSONA_SCRIPT_SRC =
-    'https://cdn.withpersona.com/dist/persona-v4.12.0.js';
+    'https://cdn.withpersona.com/dist/persona-v4.12.1.js';
   static PLAID_SCRIPT_SRC =
     'https://cdn.plaid.com/link/v2/stable/link-initialize.js';
   static BTC_ICON = 'https://images.cybrid.xyz/sdk/assets/svg/color/btc.svg';


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [x] Bug fix

### Linked issue
- [x] Not tracked

### Why
`onAddAccount` is sometimes returning a `create` workflow instead of `update` when a class variable isn't set.

### How
Adjust `onAddAccount` to look at a scoped const instead.