### PR TITLE
fix: Plaid mobile

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -226,7 +226,8 @@
               "library/src/shared/utility/*",
               "library/src/shared/pipes/asset/mock-asset.pipe.ts",
               "library/src/shared/pipes/assetFormat/mock-asset-format.pipe.ts",
-              "library/src/app/components/identity-verification/*.ts"
+              "library/src/app/components/identity-verification/*.ts",
+              "library/src/app/components/bank-account-management/bank-account-connect/*.ts"
             ],
             "inlineStyleLanguage": "scss",
             "styles": ["library/src/shared/styles/theme.scss"],

--- a/angular.json
+++ b/angular.json
@@ -226,8 +226,7 @@
               "library/src/shared/utility/*",
               "library/src/shared/pipes/asset/mock-asset.pipe.ts",
               "library/src/shared/pipes/assetFormat/mock-asset-format.pipe.ts",
-              "library/src/app/components/identity-verification/*.ts",
-              "library/src/app/components/bank-account-management/bank-account-connect/*.ts"
+              "library/src/app/components/identity-verification/*.ts"
             ],
             "inlineStyleLanguage": "scss",
             "styles": ["library/src/shared/styles/theme.scss"],

--- a/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.html
+++ b/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.html
@@ -79,7 +79,7 @@
                 mat-flat-button
                 color="primary"
                 matStepperPrevious
-                (click)="onAddAccount()"
+                (click)="processAccount()"
               >
                 {{ 'resume' | translate }}
               </button>

--- a/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.spec.ts
+++ b/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.spec.ts
@@ -148,7 +148,22 @@ describe('BankAccountConnectComponent', () => {
     MockConfigService.getConfig$.calls.reset();
     MockConfigService.getCustomer$.calls.reset();
     MockRoutingService.handleRoute.calls.reset();
+    MockConfigService.getConfig$.and.returnValue(of(TestConstants.CONFIG));
     MockBankAccountService.createWorkflow.calls.reset();
+    MockBankAccountService.createWorkflow.and.returnValue(
+      of(TestConstants.WORKFLOW_BANK_MODEL)
+    );
+    MockBankAccountService.getWorkflow.and.returnValue(
+      of(TestConstants.WORKFLOW_BANK_MODEL_WITH_DETAILS)
+    );
+    MockBankAccountService.patchExternalBankAccount.and.returnValue(
+      of(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL)
+    );
+    MockBankAccountService.createExternalBankAccount.and.returnValue(
+      of(TestConstants.EXTERNAL_BANK_ACCOUNT_BANK_MODEL)
+    );
+    MockBankAccountService.getPlaidClient.and.returnValue(of(false));
+    MockActivatedRoute.queryParams = of({});
   });
 
   it('should create', () => {
@@ -362,6 +377,7 @@ describe('BankAccountConnectComponent', () => {
   describe('when bootstrapping Plaid', () => {
     beforeEach(() => {
       MockBankAccountService.setPlaidClient.calls.reset();
+      MockBankAccountService.getPlaidClient.and.returnValue(of(false));
     });
     describe('when there is no Plaid client', () => {
       it('should create a Plaid client', () => {
@@ -374,11 +390,9 @@ describe('BankAccountConnectComponent', () => {
     });
 
     describe('when there is a Plaid client', () => {
-      beforeEach(() => {
-        MockBankAccountService.getPlaidClient.and.returnValue(of(true));
-      });
-
       it('should not create a Plaid client', () => {
+        MockBankAccountService.getPlaidClient.and.returnValue(of(true));
+
         component.bootstrapPlaid('', '');
 
         expect(MockBankAccountService.setPlaidClient).not.toHaveBeenCalled();
@@ -397,133 +411,128 @@ describe('BankAccountConnectComponent', () => {
     });
   });
 
-  describe('when Plaid is successful', () => {});
+  describe('when Plaid is successful', () => {
+    describe('with no existing external bank account', () => {
+      describe('with multiple accounts returned', () => {
+        it('should return an error', () => {
+          const errorSpy = spyOn(component.error$, 'next');
 
-  // it('should bootstrap the Plaid sdk', () => {
-  //   // Default
-  //   component.bootstrapPlaid('');
-  //
-  //   // Previously loaded client
-  //   MockBankAccountService.getPlaidClient.and.returnValue(of(true));
-  //   component.bootstrapPlaid('');
-  //
-  //   // Ensure only one client has been loaded
-  //   expect(MockBankAccountService.setPlaidClient).toHaveBeenCalledOnceWith(
-  //     true
-  //   );
-  //
-  //   // Reset
-  //   MockBankAccountService.getPlaidClient.and.returnValue(of(false));
-  // });
-  //
-  // it('should handle errors when bootstrapping plaid', () => {
-  //   MockBankAccountService.getPlaidClient.and.returnValue(error$);
-  //
-  //   component.bootstrapPlaid('');
-  //
-  //   expect(MockErrorService.handleError).toHaveBeenCalled();
-  //   expect(MockEventService.handleEvent).toHaveBeenCalled();
-  //
-  //   // Reset
-  //   MockBankAccountService.getPlaidClient.and.returnValue(error$);
-  // });
-  //
-  // it('should handle plaidOnSuccess() with multiple accounts selected', () => {
-  //   const errorSpy = spyOn(component.error$, 'next');
-  //
-  //   component.plaidOnSuccess('', {
-  //     accounts: [
-  //       { name: '', id: '', iso_currency_code: '' },
-  //       { name: '', id: '', iso_currency_code: '' }
-  //     ]
-  //   });
-  //   expect(errorSpy).toHaveBeenCalledWith(true);
-  //   expect(MockErrorService.handleError).toHaveBeenCalled();
-  //   expect(MockEventService.handleEvent).toHaveBeenCalled();
-  // });
-  //
-  // it('should handle plaidOnSuccess() with a supported currency code', () => {
-  //   component.plaidOnSuccess('', {
-  //     accounts: [{ name: '', id: '', iso_currency_code: 'USD' }]
-  //   });
-  //   expect(MockBankAccountService.createExternalBankAccount).toHaveBeenCalled();
-  // });
-  //
-  // it('should handle plaidOnSuccess() with an unsupported currency code', () => {
-  //   const errorSpy = spyOn(component.error$, 'next');
-  //
-  //   component.plaidOnSuccess('', {
-  //     accounts: [{ name: '', id: '', iso_currency_code: 'CAD' }]
-  //   });
-  //   expect(errorSpy).toHaveBeenCalledWith(true);
-  // });
-  //
-  // it('should handle plaidOnSuccess() with an undefined iso_currency_code', () => {
-  //   const getCurrencyCodeSpy = spyOn(component, 'getCurrencyCode');
-  //
-  //   component.plaidOnSuccess('', {
-  //     accounts: [{ name: '', id: '', iso_currency_code: undefined }]
-  //   });
-  //   expect(getCurrencyCodeSpy).toHaveBeenCalled();
-  // });
-  //
-  // it('should handle plaidOnSuccess() in update mode', () => {
-  //   // Define an external account guid to trigger update mode
-  //   // @ts-ignore
-  //   component.externalBankAccountGuid = '';
-  //
-  //   component.plaidOnSuccess('', {
-  //     accounts: [{ name: '', id: '', iso_currency_code: 'USD' }]
-  //   });
-  //
-  //   expect(MockBankAccountService.patchExternalBankAccount).toHaveBeenCalled();
-  // });
-  //
-  // it('should handle getCurrencyCode() returning undefined', () => {
-  //   // Ensure stepper is defined
-  //   component.stepper = { next: () => {} } as MatStepper;
-  //   const stepperSpy = spyOn(component.stepper, 'next');
-  //
-  //   MockDialog.open.and.returnValue({
-  //     afterClosed: () => of(undefined)
-  //   });
-  //
-  //   component.plaidOnSuccess('', {
-  //     accounts: [{ name: '', id: '', iso_currency_code: undefined }]
-  //   });
-  //   expect(stepperSpy).toHaveBeenCalled();
-  //
-  //   // Reset
-  //   MockDialog.open.and.returnValue({
-  //     afterClosed: () => of('USD')
-  //   });
-  // });
-  //
-  // it('should handle a successful plaidOnExit()', () => {
-  //   // Ensure stepper is defined
-  //   component.stepper = { next: () => {} } as MatStepper;
-  //   const stepperSpy = spyOn(component.stepper, 'next');
-  //
-  //   component.plaidOnExit('', {});
-  //   expect(stepperSpy).toHaveBeenCalled();
-  // });
-  //
-  // it('should handle plaidOnExit() with metadata', () => {
-  //   component.stepper = { next: () => {} } as MatStepper;
-  //   component.plaidOnExit('', {});
-  //
-  //   expect(MockEventService.handleEvent).toHaveBeenCalled();
-  // });
-  //
-  // it('should handle plaidOnExit() with an error', () => {
-  //   component.plaidOnExit('error', {});
-  //
-  //   expect(MockErrorService.handleError).toHaveBeenCalled();
-  //   expect(MockEventService.handleEvent).toHaveBeenCalled();
-  // });
-  //
-  // it('should navigate onComplete()', () => {
-  //   component.onComplete();
-  //   expect(MockRoutingService.handleRoute).toHaveBeenCalled();
-  // });
+          component.plaidOnSuccess('', {
+            accounts: [
+              { name: '', id: '', iso_currency_code: '' },
+              { name: '', id: '', iso_currency_code: '' }
+            ]
+          });
+          expect(errorSpy).toHaveBeenCalledWith(true);
+          expect(MockErrorService.handleError).toHaveBeenCalled();
+          expect(MockEventService.handleEvent).toHaveBeenCalled();
+        });
+      });
+
+      describe('with one account returned', () => {
+        describe('with a supported currency code', () => {
+          it('should create an external bank account', () => {
+            component.plaidOnSuccess('', {
+              accounts: [{ name: '', id: '', iso_currency_code: 'USD' }]
+            });
+            expect(
+              MockBankAccountService.createExternalBankAccount
+            ).toHaveBeenCalled();
+          });
+        });
+
+        describe('with an unsupported currency code', () => {
+          it('should handle plaidOnSuccess() with an unsupported currency code', () => {
+            const errorSpy = spyOn(component.error$, 'next');
+
+            component.plaidOnSuccess('', {
+              accounts: [{ name: '', id: '', iso_currency_code: 'CAD' }]
+            });
+            expect(errorSpy).toHaveBeenCalledWith(true);
+          });
+        });
+
+        describe('with an undefined iso_currency_code', () => {
+          it('should get the currency code', () => {
+            const getCurrencyCodeSpy = spyOn(component, 'getCurrencyCode');
+
+            component.plaidOnSuccess('', {
+              accounts: [{ name: '', id: '', iso_currency_code: undefined }]
+            });
+            expect(getCurrencyCodeSpy).toHaveBeenCalled();
+          });
+        });
+
+        describe('when no currency code is returned', () => {
+          it('should move to the next step', () => {
+            component.stepper = { next: () => {} } as MatStepper;
+            const stepperSpy = spyOn(component.stepper, 'next');
+            component.getCurrencyCode = () => of(undefined);
+
+            component.plaidOnSuccess('', {
+              accounts: [{ name: '', id: '', iso_currency_code: undefined }]
+            });
+
+            expect(stepperSpy).toHaveBeenCalled();
+          });
+        });
+      });
+    });
+
+    describe('with an existing external bank account', () => {
+      beforeEach(() => {
+        component.externalBankAccountGuid = '';
+      });
+
+      it('should patch the external bank account', () => {
+        component.plaidOnSuccess('', {
+          accounts: [{ name: '', id: '', iso_currency_code: 'USD' }]
+        });
+
+        expect(
+          MockBankAccountService.patchExternalBankAccount
+        ).toHaveBeenCalled();
+      });
+
+      it('should handle errors', () => {
+        const error$Spy = spyOn(component.error$, 'next');
+        MockBankAccountService.patchExternalBankAccount.and.returnValue(error$);
+
+        component.plaidOnSuccess('', {
+          accounts: [{ name: '', id: '', iso_currency_code: 'USD' }]
+        });
+
+        expect(error$Spy).toHaveBeenCalledWith(true);
+      });
+    });
+  });
+
+  describe('when Plaid exits', () => {
+    describe('when Plaid is successful', () => {
+      it('should move to the next step', () => {
+        component.stepper = { next: () => {} } as MatStepper;
+        const stepperSpy = spyOn(component.stepper, 'next');
+
+        component.plaidOnExit('', {});
+        expect(stepperSpy).toHaveBeenCalled();
+        expect(MockEventService.handleEvent).toHaveBeenCalled();
+      });
+    });
+
+    describe('when Plaid is unsuccessful', () => {
+      it('should handle errors', () => {
+        component.plaidOnExit('error', {});
+
+        expect(MockErrorService.handleError).toHaveBeenCalled();
+        expect(MockEventService.handleEvent).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when complete', () => {
+    it('should navigate', () => {
+      component.onComplete();
+      expect(MockRoutingService.handleRoute).toHaveBeenCalled();
+    });
+  });
 });

--- a/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.ts
+++ b/library/src/app/components/bank-account-management/bank-account-connect/bank-account-connect.component.ts
@@ -138,17 +138,19 @@ export class BankAccountConnectComponent implements OnInit {
   }
 
   getQueryParam(param: string): string | null {
-    return (
-      new URLSearchParams(this.window.location.search).get(param) ??
-      (() => {
-        const queryStringIndex = this.window.location.hash.indexOf('?');
-        return queryStringIndex !== -1
-          ? new URLSearchParams(
-              this.window.location.hash.substring(queryStringIndex)
-            ).get(param)
-          : null;
-      })()
+    const searchParams = new URLSearchParams(this.window.location.search);
+    const hashParams = new URLSearchParams(
+      this.window.location.hash.substring(
+        this.window.location.hash.indexOf('?') + 1
+      )
     );
+
+    const paramValueFromSearch = searchParams.get(param);
+    const paramValueFromHash = hashParams.get(param);
+
+    return paramValueFromSearch !== null
+      ? paramValueFromSearch
+      : paramValueFromHash;
   }
 
   isMobile(): boolean {


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [x] Bug fix

### Linked issue
- [x] Not tracked

### Why
When performing a mobile refresh the component is trying to create a new external bank account.

### How
Ensure that a mobile refresh generates the correct workflow. Also refactored tests to be more readable and concise.