### PR TITLE
feat: remove idv error codes

### DIFF
--- a/library/src/app/components/identity-verification/identity-content/identity-content.component.html
+++ b/library/src/app/components/identity-verification/identity-content/identity-content.component.html
@@ -17,9 +17,6 @@
         <mat-icon color="warn">cancel</mat-icon>
         <strong>{{ 'identityVerification.rejected' | translate }}</strong>
       </div>
-      <p *ngFor="let reason of identity.failure_codes">
-        {{ reason }}
-      </p>
     </div>
   </ng-container>
 </ng-container>


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [x] Feature
- [ ] Bug fix

### Linked issue
https://cybrid.atlassian.net/browse/CYB-3127

### Why
DollarePe has requested that `identity_verifictation` failure codes not be displayed to the end user. This seems reasonable. It will still display a `rejected` status.

### How
By removing the `failure_codes` from display.