### PR TITLE
fix: duplicate identity verifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ workflows:
                 command: npm run lint
                 name: Lint
             - run:
-                command: npm audit --audit-level=high
+                command: npm audit --audit-level=high --omit=dev
                 name: Audit
             - run:
                 command: npm run package:library

--- a/library/src/app/components/identity-verification/identity-verification.component.spec.ts
+++ b/library/src/app/components/identity-verification/identity-verification.component.spec.ts
@@ -507,6 +507,23 @@ describe('IdentityVerificationComponent', () => {
           MockIdentityVerificationService.createIdentityVerification
         ).toHaveBeenCalled();
       });
+
+      it('when the persona_state is null', () => {
+        let identityVerificationBankModel = {
+          ...TestConstants.IDENTITY_VERIFICATION_BANK_MODEL
+        };
+        identityVerificationBankModel.persona_state = null;
+
+        MockIdentityVerificationService.getIdentityVerification.and.returnValue(
+          of(identityVerificationBankModel)
+        );
+
+        component.verifyIdentity();
+
+        expect(
+          MockIdentityVerificationService.createIdentityVerification
+        ).not.toHaveBeenCalled();
+      });
     });
 
     it('should handle errors from listing identity verifications', fakeAsync(() => {

--- a/library/src/app/components/identity-verification/identity-verification.component.ts
+++ b/library/src/app/components/identity-verification/identity-verification.component.ts
@@ -88,7 +88,8 @@ export class IdentityVerificationComponent implements OnInit, OnDestroy {
   validPersonaState = [
     IdentityVerificationWithDetails.PersonaStateEnum.Waiting,
     IdentityVerificationWithDetails.PersonaStateEnum.Reviewing,
-    IdentityVerificationWithDetails.PersonaStateEnum.Processing
+    IdentityVerificationWithDetails.PersonaStateEnum.Processing,
+    null
   ];
 
   constructor(


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [x] Bug fix

### Linked issue
https://cybrid.atlassian.net/browse/CYB-3075

### Why
When encountering an idv with a `persona_state` that is `null` we were generating a new identity verification instead of polling on the idv.

### How
By adding the state to the list of allowed states.